### PR TITLE
Use SplitN instead of split

### DIFF
--- a/fixtures/equals.env
+++ b/fixtures/equals.env
@@ -1,0 +1,2 @@
+export OPTION_A='postgres://localhost:5432/database?sslmode=disable'
+

--- a/godotenv.go
+++ b/godotenv.go
@@ -138,7 +138,7 @@ func parseLine(line string) (key string, value string, err error) {
 	}
 
 	// now split key from value
-	splitString := strings.Split(line, "=")
+	splitString := strings.SplitN(line, "=", 2)
 
 	if len(splitString) != 2 {
 		// try yaml mode!

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -93,6 +93,15 @@ func TestLoadExportedEnv(t *testing.T) {
 	loadEnvAndCompareValues(t, envFileName, expectedValues)
 }
 
+func TestLoadEqualsEnv(t *testing.T) {
+	envFileName := "fixtures/equals.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "postgres://localhost:5432/database?sslmode=disable",
+	}
+
+	loadEnvAndCompareValues(t, envFileName, expectedValues)
+}
+
 func TestLoadQuotedEnv(t *testing.T) {
 	envFileName := "fixtures/quoted.env"
 	expectedValues := map[string]string{


### PR DESCRIPTION
Using splitN instead of split permits to have equals in the value.
This is useful for example for `DATABASE_URL` keys which probably in local mode needs SSL disabled
