### PR TITLE
Fix issue reading file.

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -104,7 +104,9 @@ func loadFile(filename string) (err error) {
 	}
 
 	for key, value := range envMap {
-		os.Setenv(key, value)
+		if os.Getenv(key) == "" {
+			os.Setenv(key, value)
+		}
 	}
 
 	return
@@ -129,7 +131,7 @@ func readFile(filename string) (envMap map[string]string, err error) {
 		if !isIgnoredLine(fullLine) {
 			key, value, err := parseLine(fullLine)
 
-			if err == nil && os.Getenv(key) == "" {
+			if err == nil {
 				envMap[key] = value
 			}
 		}


### PR DESCRIPTION
Hi, thanks for porting this library, it's very useful!

I found a corner case that you might have not considered. It's not probably common, but it makes this library to not work in my case.

This is what I did to find this issue:

1. Inside my app, I use `godotenv.Read` to load the file into my own custom environment.
2. I use foreman to boot the application.

Since foreman already loads the `.env` file, the `Read` function returns an empty map.

I think it's more correct to return always the values in the file in the function `Read`, but put the ward to not override the environment for the function `Load.`

This change solves my issue, what do you think?