### PR TITLE
Add Overload methods.

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -36,7 +36,30 @@ func Load(filenames ...string) (err error) {
 	filenames = filenamesOrDefault(filenames)
 
 	for _, filename := range filenames {
-		err = loadFile(filename)
+		err = loadFile(filename, false)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Overload will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Overload without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Overload("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+func Overload(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
 		if err != nil {
 			return // return early on a spazout
 		}
@@ -90,14 +113,14 @@ func filenamesOrDefault(filenames []string) []string {
 	return filenames
 }
 
-func loadFile(filename string) error {
+func loadFile(filename string, overload bool) error {
 	envMap, err := readFile(filename)
 	if err != nil {
 		return err
 	}
 
 	for key, value := range envMap {
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" || overload {
 			os.Setenv(key, value)
 		}
 	}


### PR DESCRIPTION
Hello and good morning. 

I have a use-case for an Overload method (manually implemented [here in one of my packages](https://github.com/jmervine/env/blob/master/env.go#L71-L83)) and thought I would offer up an addition as it's implemented in [the `dotenv` Ruby gem](http://www.rubydoc.info/gems/dotenv/2.0.2/Dotenv#overload-class_method).

I only added a limited number of `TestOverload{...}` methods, as the underlying functionality is the same across both and therefore more felt redundant. I'm happy to add the rest if you'd like.

While I don't have access to a Windows machine, I've tested it on go1.{3,4,5} using the [official golang docker image](https://hub.docker.com/_/golang/):

```
jmervine@debian:~/.go/src/github.com/jmervine/godotenv$ for v in `echo "3 4 5"`; do
> echo "[v1.${v}]: go test ."                                                                                                                               
> docker run --rm -v $(pwd):/go/src/github.com/jmervine/godotenv -w /go/src/github.com/jmervine/godotenv golang:1.${v} go test .
> done
[v1.3]: go test .
ok      github.com/jmervine/godotenv    0.002s
[v1.4]: go test .
ok      github.com/jmervine/godotenv    0.002s
[v1.5]: go test .
ok      github.com/jmervine/godotenv    0.002s
```

I'll be traveling for the next week, so it may take me a bit to respond to/address any comments.

Cheers!
J
