### PR TITLE
Improve error handling

### DIFF
--- a/fixtures/invalid1.env
+++ b/fixtures/invalid1.env
@@ -1,0 +1,2 @@
+INVALID LINE
+foo=bar

--- a/godotenv.go
+++ b/godotenv.go
@@ -149,11 +149,13 @@ func readFile(filename string) (envMap map[string]string, err error) {
 
 	for _, fullLine := range lines {
 		if !isIgnoredLine(fullLine) {
-			key, value, err := parseLine(fullLine)
+			var key, value string
+			key, value, err = parseLine(fullLine)
 
-			if err == nil {
-				envMap[key] = value
+			if err != nil {
+				return
 			}
+			envMap[key] = value
 		}
 	}
 	return

--- a/godotenv.go
+++ b/godotenv.go
@@ -143,6 +143,10 @@ func readFile(filename string) (envMap map[string]string, err error) {
 		lines = append(lines, scanner.Text())
 	}
 
+	if err = scanner.Err(); err != nil {
+		return
+	}
+
 	for _, fullLine := range lines {
 		if !isIgnoredLine(fullLine) {
 			key, value, err := parseLine(fullLine)

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -269,3 +269,12 @@ func TestLinesToIgnore(t *testing.T) {
 		t.Error("ignoring a perfectly valid line to parse")
 	}
 }
+
+func TestErrorReadDirectory(t *testing.T) {
+	envFileName := "fixtures/"
+	envMap, err := Read(envFileName)
+
+	if err == nil {
+		t.Errorf("Expected error, got %v", envMap)
+	}
+}

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -278,3 +278,11 @@ func TestErrorReadDirectory(t *testing.T) {
 		t.Errorf("Expected error, got %v", envMap)
 	}
 }
+
+func TestErrorParsing(t *testing.T) {
+	envFileName := "fixtures/invalid1.env"
+	envMap, err := Read(envFileName)
+	if err == nil {
+		t.Errorf("Expected error, got %v", envMap)
+	}
+}


### PR DESCRIPTION
* propagate errors from `scanner` (e.g.: passing path to directory to `Read()`)
* propagate line parsing errors when parsing file - currently they are quietly ignored