### PR TITLE
Respect preset empty external env vars

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -119,8 +119,15 @@ func loadFile(filename string, overload bool) error {
 		return err
 	}
 
+	currentEnv := map[string]bool{}
+	rawEnv := os.Environ()
+	for _, rawEnvLine := range rawEnv {
+		key := strings.Split(rawEnvLine, "=")[0]
+		currentEnv[key] = true
+	}
+
 	for key, value := range envMap {
-		if os.Getenv(key) == "" || overload {
+		if !currentEnv[key] || overload {
 			os.Setenv(key, value)
 		}
 	}

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -100,10 +100,12 @@ func TestLoadDoesNotOverride(t *testing.T) {
 	// ensure NO overload
 	presets := map[string]string{
 		"OPTION_A": "do_not_override",
+		"OPTION_B": "",
 	}
 
 	expectedValues := map[string]string{
 		"OPTION_A": "do_not_override",
+		"OPTION_B": "",
 	}
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, presets)
 }


### PR DESCRIPTION
Fix for #28.

`os.Getenv()` returns a string, but no error or boolean to specify set/unset. I'd naively checked for an empty string to assert that a value isn't set in env but an empty value is still valid.

This changes the env check to manually iterate over the raw env to see which keys are present.