### PR TITLE
Try to get .env filename from env first

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -108,7 +108,11 @@ func Exec(filenames []string, cmd string, cmdArgs []string) error {
 
 func filenamesOrDefault(filenames []string) []string {
 	if len(filenames) == 0 {
-		return []string{".env"}
+		filename, exists := os.LookupEnv("DOTENV_FILENAME")
+		if !exists {
+			filename = ".env"
+		}
+		return []string{filename}
 	}
 	return filenames
 }


### PR DESCRIPTION
Inception warning!! 😄 

TL;DR: this patch allows us to do: 
`DOTENV_FILENAME=/directory/.env godotenv /bin/application`
or configure `DOTENV_FILENAME` as env var for an app that has autoload enabled.

Long explanation:
We're using `drone` for CI, and the latest versions are autoloading env vars using godotenv. The problem is that in our setup (mesos/marathon) we cannot put files wherever we want, but we can configure environment variables!

So with this little change we can run the drone image, put the config file in a specific dir and by using an env variable, make drone load it using godotenv.

I know you don't want to have much differences from the original dotenv.. If this is much of a problem, I can make a PR for them too. I don't know much about ruby, but don't know much about go as well!

Regards!