### PR TITLE
Fix some small parsing bugs

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -198,11 +198,11 @@ func parseLine(line string) (key string, value string, err error) {
 		line = strings.Join(segmentsToKeep, "#")
 	}
 
-	// now split key from value
+	firstEquals := strings.Index(line, "=")
+	firstColon := strings.Index(line, ":")
 	splitString := strings.SplitN(line, "=", 2)
-
-	if len(splitString) != 2 {
-		// try yaml mode!
+	if firstColon != -1 && (firstColon < firstEquals || firstEquals == -1) {
+		//this is a yaml-style line
 		splitString = strings.SplitN(line, ":", 2)
 	}
 

--- a/godotenv.go
+++ b/godotenv.go
@@ -234,7 +234,7 @@ func parseValue(value string) string {
 		last := string(value[len(value)-1:])
 		if first == last && strings.ContainsAny(first, `"'`) {
 			// pull the quotes off the edges
-			value = strings.Trim(value, `"'`)
+			value = value[1 : len(value)-1]
 			// handle escapes
 			escapeRegex := regexp.MustCompile(`\\.`)
 			value = escapeRegex.ReplaceAllStringFunc(value, func(match string) string {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -205,6 +205,12 @@ func TestParsing(t *testing.T) {
 	// parses yaml style options
 	parseAndCompare(t, "OPTION_A: 1", "OPTION_A", "1")
 
+	//parses yaml values with equal signs
+	parseAndCompare(t, "OPTION_A: Foo=bar", "OPTION_A", "Foo=bar")
+
+	// parses non-yaml options with colons
+	parseAndCompare(t, "OPTION_A=1:B", "OPTION_A", "1:B")
+
 	// parses export keyword
 	parseAndCompare(t, "export OPTION_A=2", "OPTION_A", "2")
 	parseAndCompare(t, `export OPTION_B='\n'`, "OPTION_B", "\n")

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -199,6 +199,9 @@ func TestParsing(t *testing.T) {
 	// parses escaped double quotes
 	parseAndCompare(t, `FOO="escaped\"bar"`, "FOO", `escaped"bar`)
 
+	// parses single quotes inside double quotes
+	parseAndCompare(t, `FOO="'d'"`, "FOO", `'d'`)
+
 	// parses yaml style options
 	parseAndCompare(t, "OPTION_A: 1", "OPTION_A", "1")
 

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -238,6 +238,11 @@ func TestParsing(t *testing.T) {
 	parseAndCompare(t, `FOO="ba#r"`, "FOO", "ba#r")
 	parseAndCompare(t, "FOO='ba#r'", "FOO", "ba#r")
 
+	//newlines and backslashes should be escaped
+	parseAndCompare(t, `FOO="bar\n\ b\az"`, "FOO", "bar\n baz")
+	parseAndCompare(t, `FOO="bar\\\n\ b\az"`, "FOO", "bar\\\n baz")
+	parseAndCompare(t, `FOO="bar\\r\ b\az"`, "FOO", "bar\\r baz")
+
 	// it 'throws an error if line format is incorrect' do
 	// expect{env('lol$wut')}.to raise_error(Dotenv::FormatError)
 	badlyFormattedLine := "lol$wut"


### PR DESCRIPTION
Hi, I found/fixed a few small issues:

- Values with leading/trailing quotes were getting over-trimmed (`KEY="'value'"` => `value` rather than `'value'`)
- YAML-style parsing was not being used correctly if the value contained an equal-sign (ex: `KEY: value=v1`)
- Escapes were a little too limited.

There are some more lurking around too, I think. I'd be willing to rewrite the core as a state machine. The benefit of that is that weird edge cases can be taken care of more easily (complications around real nested quotes, escapes, etc). The downside is that it might not be worth the effort to cover those edge cases, and on the whole is less obvious. `strings.SplitN("=", 2)` is generally easier to read than `if c == '='{ state=Value; continue;}` etc.

If it's something you're not fully opposed to I can do it and see how it ends up looking.