### PR TITLE
support for writing envs out in dotenv format

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+
 // Load will read your env file(s) and load them into ENV for this process.
 //
 // Call this function as close as possible to the start of your program (ideally in main)
@@ -297,9 +299,15 @@ func isIgnoredLine(line string) bool {
 }
 
 func doubleQuoteEscape(line string) string {
-	line = strings.Replace(line, `\`, `\\`, -1)
-	line = strings.Replace(line, "\n", `\n`, -1)
-	line = strings.Replace(line, "\r", `\r`, -1)
-	line = strings.Replace(line, `"`, `\"`, -1)
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
 	return line
 }

--- a/godotenv.go
+++ b/godotenv.go
@@ -122,8 +122,8 @@ func Parse(r io.Reader) (envMap map[string]string, err error) {
 	return
 }
 
-//ParseString reads an env file from a string, returning a map of keys and values.
-func ParseString(str string) (envMap map[string]string, err error) {
+//Unmarshal reads an env file from a string, returning a map of keys and values.
+func Unmarshal(str string) (envMap map[string]string, err error) {
 	return Parse(strings.NewReader(str))
 }
 
@@ -146,7 +146,7 @@ func Exec(filenames []string, cmd string, cmdArgs []string) error {
 
 // Write serializes the given environment and writes it to a file
 func Write(envMap map[string]string, filename string) error {
-	content, error := WriteString(envMap)
+	content, error := Marshal(envMap)
 	if error != nil {
 		return error
 	}
@@ -158,10 +158,9 @@ func Write(envMap map[string]string, filename string) error {
 	return err
 }
 
-// WriteString outputs the given environment as a dotenv-formatted environment file.
-//
+// Marshal outputs the given environment as a dotenv-formatted environment file.
 // Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
-func WriteString(envMap map[string]string) (string, error) {
+func Marshal(envMap map[string]string) (string, error) {
 	lines := make([]string, 0, len(envMap))
 	for k, v := range envMap {
 		lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -331,8 +331,8 @@ func TestErrorParsing(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	writeAndCompare := func(env string, expected string) {
-		envMap, _ := ParseString(env)
-		actual, _ := WriteString(envMap)
+		envMap, _ := Unmarshal(env)
+		actual, _ := Marshal(envMap)
 		if expected != actual {
 			t.Errorf("Expected '%v' (%v) to write as '%v', got '%v' instead.", env, envMap, expected, actual)
 		}
@@ -358,11 +358,11 @@ func TestRoundtrip(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		rep, err := WriteString(env)
+		rep, err := Marshal(env)
 		if err != nil {
 			continue
 		}
-		roundtripped, err := ParseString(rep)
+		roundtripped, err := Unmarshal(rep)
 		if err != nil {
 			continue
 		}

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -346,8 +346,8 @@ func TestWrite(t *testing.T) {
 	writeAndCompare(`key=va"lu"e`, `key="va\"lu\"e"`)
 	//but single quotes are left alone
 	writeAndCompare(`key=va'lu'e`, `key="va'lu'e"`)
-	// newlines and backslashes are escaped
-	writeAndCompare(`foo="ba\n\r\\r!"`, `foo="ba\n\r\\r!"`)
+	// newlines, backslashes, and some other special chars are escaped
+	writeAndCompare(`foo="$ba\n\r\\r!"`, `foo="\$ba\n\r\\r\!"`)
 }
 
 func TestRoundtrip(t *testing.T) {


### PR DESCRIPTION
implements: #31 (give writing out dotenv files a shot)
requires: https://github.com/joho/godotenv/pull/34 (fixes for parsing escapes -- `\\` in particular)

A few months ago you said I could give roundtripping dotenv files a whirl. Here's the whirl :)

It's is useful for systems that create environments for other processes or change their own environments. That way everyone involved can use the same package. It also came in handy for exercising the parser more heavily. The output values are double-quoted and backslash escaped.

godotenv gets the following new members:

```go
// Write serializes the given environment and writes it to a file
func Write(envMap map[string]string, filename string) error {}

// Marshal outputs the given environment as a dotenv-formatted environment file.
// Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
func Marshal(envMap map[string]string) (string, error) {}

//Unmarshal reads an env file from a string, returning a map of keys and values.
func Unmarshal(str string) (envMap map[string]string, err error) {}
```