### PR TITLE
Parse(reader) as alternative to Read(filenames)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ myEnv, err := godotenv.Read()
 s3Bucket := myEnv["S3_BUCKET"]
 ```
 
+... or from an `io.Reader` instead of a local file
+
+```go
+reader := getRemoteFile()
+myEnv, err := godotenv.Parse(reader)
+```
+
 ### Command Mode
 
 Assuming you've installed the command as above and you've got `$GOPATH/bin` in your `$PATH`

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -1,6 +1,7 @@
 package godotenv
 
 import (
+	"bytes"
 	"os"
 	"testing"
 )
@@ -90,6 +91,23 @@ func TestReadPlainEnv(t *testing.T) {
 	for key, value := range expectedValues {
 		if envMap[key] != value {
 			t.Error("Read got one of the keys wrong")
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	envMap, err := Parse(bytes.NewReader([]byte("ONE=1\nTWO='2'\nTHREE = \"3\"")))
+	expectedValues := map[string]string{
+		"ONE":   "1",
+		"TWO":   "2",
+		"THREE": "3",
+	}
+	if err != nil {
+		t.Fatalf("error parsing env: %v", err)
+	}
+	for key, value := range expectedValues {
+		if envMap[key] != value {
+			t.Errorf("expected %s to be %s, got %s", key, value, envMap[key])
 		}
 	}
 }


### PR DESCRIPTION
Adds `func Parse(r io.Reader)` to the public API, which returns a `map[string]string` just like the existing `func Read(filenames ...string)` but reads from an `io.Reader` rather than a list of filenames.

This avoids needing to create a temporary file in tools like https://github.com/cultureamp/s3dotenv which load a dotenv file from a non-filesystem source.