### PR TITLE
Implemented FetchEnv to fail quickly when variable is not set

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -16,6 +16,7 @@ package godotenv
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -124,7 +125,7 @@ func Parse(r io.Reader) (envMap map[string]string, err error) {
 func FetchEnv(key string) string {
 	val := os.Getenv(key)
 	if val == "" {
-		panic("missing ENV variable")
+		panic(fmt.Sprintf("Missing '%s' environment variable", key))
 	}
 	return val
 }

--- a/godotenv.go
+++ b/godotenv.go
@@ -118,6 +118,17 @@ func Parse(r io.Reader) (envMap map[string]string, err error) {
 	return
 }
 
+// FetchEnv returns environment variable if is set but panic when isn't (fail fast approach)
+// Example usage:
+//		godotenv.FetchEnv("PORT")
+func FetchEnv(key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		panic("missing ENV variable")
+	}
+	return val
+}
+
 // Exec loads env vars from the specified filenames (empty map falls back to default)
 // then executes the cmd specified.
 //

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -308,3 +308,20 @@ func TestErrorParsing(t *testing.T) {
 		t.Errorf("Expected error, got %v", envMap)
 	}
 }
+
+func TestFetchEnv(t *testing.T) {
+	os.Setenv("FETCH_ENV", "SET")
+	res := FetchEnv("FETCH_ENV")
+	if res != "SET" {
+		t.Errorf("The variable FETCH_ENV not set")
+	}
+}
+
+func TestFetchEnvPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("The code did not panic when ENV variable was not set")
+		}
+	}()
+	FetchEnv("FETCH_ENV_PANIC")
+}


### PR DESCRIPTION
#### What does this PR accomplish?

- Provides additional method which will panic in case of missing variable. It's common behaviour in most applications to fail quickly on runtime when ENV variable required by app is not set.