### PR TITLE
Sort output of Marshal/Write

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -165,6 +166,7 @@ func Marshal(envMap map[string]string) (string, error) {
 	for k, v := range envMap {
 		lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))
 	}
+	sort.Strings(lines)
 	return strings.Join(lines, "\n"), nil
 }
 

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -348,6 +348,9 @@ func TestWrite(t *testing.T) {
 	writeAndCompare(`key=va'lu'e`, `key="va'lu'e"`)
 	// newlines, backslashes, and some other special chars are escaped
 	writeAndCompare(`foo="$ba\n\r\\r!"`, `foo="\$ba\n\r\\r\!"`)
+	// lines should be sorted
+	writeAndCompare("foo=bar\nbaz=buzz", "baz=\"buzz\"\nfoo=\"bar\"")
+
 }
 
 func TestRoundtrip(t *testing.T) {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -351,20 +351,20 @@ func TestWrite(t *testing.T) {
 }
 
 func TestRoundtrip(t *testing.T) {
-	fixtures := []string{"equals.env", "exported.env", "invalid1.env", "plain.env", "quoted.env"}
+	fixtures := []string{"equals.env", "exported.env", "plain.env", "quoted.env"}
 	for _, fixture := range fixtures {
 		fixtureFilename := fmt.Sprintf("fixtures/%s", fixture)
 		env, err := readFile(fixtureFilename)
 		if err != nil {
-			continue
+			t.Errorf("Expected '%s' to read without error (%v)", fixtureFilename, err)
 		}
 		rep, err := Marshal(env)
 		if err != nil {
-			continue
+			t.Errorf("Expected '%s' to Marshal (%v)", fixtureFilename, err)
 		}
 		roundtripped, err := Unmarshal(rep)
 		if err != nil {
-			continue
+			t.Errorf("Expected '%s' to Mashal and Unmarshal (%v)", fixtureFilename, err)
 		}
 		if !reflect.DeepEqual(env, roundtripped) {
 			t.Errorf("Expected '%s' to roundtrip as '%v', got '%v' instead", fixtureFilename, env, roundtripped)


### PR DESCRIPTION
The order of lines in `Marshal`'d godotenv files is randomized by `Map` iteration. That's not ideal for callers who may be committing the results or relying on them to be consistent.

What do you think of sorting the lines so that they have a predictable order?
