### PR TITLE
support embed command in dotenv file

### DIFF
--- a/fixtures/embed_cmd.env
+++ b/fixtures/embed_cmd.env
@@ -1,0 +1,1 @@
+OPTION_A=$(echo 123)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/joho/godotenv

--- a/godotenv.go
+++ b/godotenv.go
@@ -27,6 +27,16 @@ import (
 
 const doubleQuoteSpecialChars = "\\\n\r\"!$`"
 
+var shouldParseEmbed bool = false
+
+func EnableEmbed() {
+	shouldParseEmbed = true
+}
+
+func DisableEmbed() {
+	shouldParseEmbed = false
+}
+
 // Load will read your env file(s) and load them into ENV for this process.
 //
 // Call this function as close as possible to the start of your program (ideally in main)
@@ -292,11 +302,13 @@ func parseValue(value string, envMap map[string]string) string {
 	}
 
 	// embed commands
-	if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
-		cmdStr := value[2 : len(value)-1]
-		cmd := exec.Command("/bin/sh", "-c", cmdStr)
-		out, _ := cmd.Output()
-		value = strings.Trim(string(out), " \n\t")
+	if shouldParseEmbed {
+		if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
+			cmdStr := value[2 : len(value)-1]
+			cmd := exec.Command("/bin/sh", "-c", cmdStr)
+			out, _ := cmd.Output()
+			value = strings.Trim(string(out), " \n\t")
+		}
 	}
 
 	// expand variables

--- a/godotenv.go
+++ b/godotenv.go
@@ -291,6 +291,14 @@ func parseValue(value string, envMap map[string]string) string {
 		}
 	}
 
+	// embed commands
+	if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
+		cmdStr := value[2 : len(value)-1]
+		cmd := exec.Command("/bin/sh", "-c", cmdStr)
+		out, _ := cmd.Output()
+		value = strings.Trim(string(out), " \n\t")
+	}
+
 	// expand variables
 	value = os.Expand(value, func(key string) string {
 		if val, ok := envMap[key]; ok {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -214,7 +214,8 @@ func TestEmbedCmd(t *testing.T) {
 		expectedValues := map[string]string{
 			"OPTION_A": "123",
 		}
-
+		EnableEmbed()
+		defer DisableEmbed()
 		loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 	}
 }

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime/internal/sys"
 	"testing"
 )
 
@@ -207,12 +208,15 @@ func TestSubstituitions(t *testing.T) {
 }
 
 func TestEmbedCmd(t *testing.T) {
-	envFileName := "fixtures/embed_cmd.env"
-	expectedValues := map[string]string{
-		"OPTION_A": "123",
-	}
+	// NOT works on windows
+	if sys.GoosWindows == 0 {
+		envFileName := "fixtures/embed_cmd.env"
+		expectedValues := map[string]string{
+			"OPTION_A": "123",
+		}
 
-	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+		loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+	}
 }
 
 func TestActualEnvVarsAreLeftAlone(t *testing.T) {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -206,6 +206,15 @@ func TestSubstituitions(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
+func TestEmbedCmd(t *testing.T) {
+	envFileName := "fixtures/embed_cmd.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "123",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
 func TestActualEnvVarsAreLeftAlone(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("OPTION_A", "actualenv")

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime/internal/sys"
+	"runtime"
 	"testing"
 )
 
@@ -209,7 +209,7 @@ func TestSubstituitions(t *testing.T) {
 
 func TestEmbedCmd(t *testing.T) {
 	// NOT works on windows
-	if sys.GoosWindows == 0 {
+	if runtime.GOOS != "windows" {
 		envFileName := "fixtures/embed_cmd.env"
 		expectedValues := map[string]string{
 			"OPTION_A": "123",


### PR DESCRIPTION
Support embed commands via `$()` (not supported on Windows)

```env
START_TIME=$(date)
```

Note that using $() might not work depending on your shell.