### PR TITLE
Do not expand variables that are not defined.

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -299,7 +299,13 @@ func parseValue(value string, envMap map[string]string) string {
 		if val, ok := os.LookupEnv(key); ok {
 			return val
 		}
-		return ""
+
+		// variable is not defined - return the key as it was
+		if withBrackets := fmt.Sprintf("${%s}", key); strings.Contains(value, withBrackets) {
+			return withBrackets
+		} else {
+			return fmt.Sprintf("$%s", key)
+		}
 	})
 	return value
 }

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -200,7 +200,7 @@ func TestSubstituitions(t *testing.T) {
 		"OPTION_B": "1",
 		"OPTION_C": "1",
 		"OPTION_D": "11",
-		"OPTION_E": "",
+		"OPTION_E": "${OPTION_NOT_DEFINED}",
 	}
 
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
@@ -217,6 +217,7 @@ func TestActualEnvVarsAreLeftAlone(t *testing.T) {
 }
 
 func TestParsing(t *testing.T) {
+	parseAndCompare(t, "FOO=Heyyyy$$", "FOO", "Heyyyy$$")
 	// unquoted values
 	parseAndCompare(t, "FOO=bar", "FOO", "bar")
 


### PR DESCRIPTION
Fixes: https://github.com/joho/godotenv/issues/52

Instead of replacing undefined variables in strings with an empty string, leave the variables as they were. 