### PR TITLE
feat(Expand Variables): Custom variable expansion instead of Go's os.Expand

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"strings"
 )
 
 var noopPresets = make(map[string]string)
@@ -161,7 +162,7 @@ func TestLoadExportedEnv(t *testing.T) {
 	envFileName := "fixtures/exported.env"
 	expectedValues := map[string]string{
 		"OPTION_A": "2",
-		"OPTION_B": "\n",
+		"OPTION_B": "\\n",
 	}
 
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
@@ -182,7 +183,7 @@ func TestLoadQuotedEnv(t *testing.T) {
 		"OPTION_A": "1",
 		"OPTION_B": "2",
 		"OPTION_C": "",
-		"OPTION_D": "\n",
+		"OPTION_D": "\\n",
 		"OPTION_E": "1",
 		"OPTION_F": "2",
 		"OPTION_G": "",
@@ -193,7 +194,7 @@ func TestLoadQuotedEnv(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
-func TestSubstituitions(t *testing.T) {
+func TestSubstitutions(t *testing.T) {
 	envFileName := "fixtures/substitutions.env"
 	expectedValues := map[string]string{
 		"OPTION_A": "1",
@@ -204,6 +205,70 @@ func TestSubstituitions(t *testing.T) {
 	}
 
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
+func TestExpanding(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			"expands variables found in values",
+			"FOO=test\nBAR=$FOO",
+			map[string]string{"FOO": "test", "BAR": "test"},
+		},
+		{
+			"parses variables wrapped in brackets",
+			"FOO=test\nBAR=${FOO}bar",
+			map[string]string{"FOO": "test", "BAR": "testbar"},
+		},
+		{
+			"expands undefined variables to an empty string",
+			"BAR=$FOO",
+			map[string]string{"BAR": ""},
+		},
+		{
+			"expands variables in double quoted strings",
+			"FOO=test\nBAR=\"quote $FOO\"",
+			map[string]string{"FOO": "test", "BAR": "quote test"},
+		},
+		{
+			"does not expand variables in single quoted strings",
+			"BAR='quote $FOO'",
+			map[string]string{"BAR": "quote $FOO"},
+		},
+		{
+			"does not expand escaped variables",
+			`FOO="foo\$BAR"`,
+			map[string]string{"FOO": "foo$BAR"},
+		},
+		{
+			"does not expand escaped variables",
+			`FOO="foo\${BAR}"`,
+			map[string]string{"FOO": "foo${BAR}"},
+		},
+		{
+			"does not expand escaped variables",
+			"FOO=test\nBAR=\"foo\\${FOO} ${FOO}\"",
+			map[string]string{"FOO": "test", "BAR": "foo${FOO} test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := Parse(strings.NewReader(tt.input))
+			if err != nil {
+				t.Errorf("Error: %s", err.Error())
+			}
+			for k, v := range tt.expected {
+				if strings.Compare(env[k], v) != 0 {
+					t.Errorf("Expected: %s, Actual: %s", v, env[k])
+				}
+			}
+		})
+	}
+
 }
 
 func TestActualEnvVarsAreLeftAlone(t *testing.T) {
@@ -247,7 +312,7 @@ func TestParsing(t *testing.T) {
 
 	// parses export keyword
 	parseAndCompare(t, "export OPTION_A=2", "OPTION_A", "2")
-	parseAndCompare(t, `export OPTION_B='\n'`, "OPTION_B", "\n")
+	parseAndCompare(t, `export OPTION_B='\n'`, "OPTION_B", "\\n")
 
 	// it 'expands newlines in quoted strings' do
 	// expect(env('FOO="bar\nbaz"')).to eql('FOO' => "bar\nbaz")


### PR DESCRIPTION
Copy over the tests from https://github.com/bkeepers/dotenv/blob/master/spec/dotenv/parser_spec.rb
related to expanding variables and implement the required changes. I also realized as part of this
that this implementation was not handling values in single quotes properly (e.g.: not the same as the ruby package mentioned) so that has been fixed as well along with the related tests.

Fixes: #52 (for real this time hopefully)