### PR TITLE
Fixing a couple whitespace bugs: ignoring leading whitespace, and supporting more kinds of empty lines

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -256,7 +256,7 @@ func parseLine(line string, envMap map[string]string) (key string, value string,
 	if strings.HasPrefix(key, "export") {
 		key = strings.TrimPrefix(key, "export")
 	}
-	key = strings.Trim(key, " ")
+	key = strings.TrimSpace(key)
 
 	// Parse the value
 	value = parseValue(splitString[1], envMap)
@@ -327,7 +327,7 @@ func expandVariables(v string, m map[string]string) string {
 }
 
 func isIgnoredLine(line string) bool {
-	trimmedLine := strings.Trim(line, " \n\t")
+	trimmedLine := strings.TrimSpace(line)
 	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
 }
 

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"testing"
 	"strings"
+	"testing"
 )
 
 var noopPresets = make(map[string]string)
@@ -355,6 +355,11 @@ func TestParsing(t *testing.T) {
 	parseAndCompare(t, `KEY="`, "KEY", "\"")
 	parseAndCompare(t, `KEY="value`, "KEY", "\"value")
 
+	// leading whitespace should be ignored
+	parseAndCompare(t, " KEY =value", "KEY", "value")
+	parseAndCompare(t, "   KEY=value", "KEY", "value")
+	parseAndCompare(t, "\tKEY=value", "KEY", "value")
+
 	// it 'throws an error if line format is incorrect' do
 	// expect{env('lol$wut')}.to raise_error(Dotenv::FormatError)
 	badlyFormattedLine := "lol$wut"
@@ -369,6 +374,10 @@ func TestLinesToIgnore(t *testing.T) {
 	// expect(env("\n \t  \nfoo=bar\n \nfizz=buzz")).to eql('foo' => 'bar', 'fizz' => 'buzz')
 	if !isIgnoredLine("\n") {
 		t.Error("Line with nothing but line break wasn't ignored")
+	}
+
+	if !isIgnoredLine("\r\n") {
+		t.Error("Line with nothing but windows-style line break wasn't ignored")
 	}
 
 	if !isIgnoredLine("\t\t ") {


### PR DESCRIPTION
I noticed that parsing a line like `\tFOO=bar` ended up with a key equal to `\tFOO` which isn't _quite_ what I expected 😉 - this fixes that by using `strings.TrimSpace` in place of `strings.Trim(..., " ")`.

I also noticed that only certain types of whitespace are ignored for "empty" lines - I've expanded that to use `strings.TrimSpace` as well.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>