### PR TITLE
Use syscall.Exec instead of cmd.Run in non-windows environment

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,19 @@
+//+build !windows
+
+package godotenv
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func execv(cmd string, cmdArgs []string) error {
+	prog, err := exec.LookPath(cmd)
+	if err != nil {
+		return err
+	}
+	args := append([]string{cmd}, cmdArgs...)
+
+	return syscall.Exec(prog, args, os.Environ())
+}

--- a/exec_windows.go
+++ b/exec_windows.go
@@ -1,0 +1,14 @@
+package godotenv
+
+import (
+	"os"
+	"os/exec"
+)
+
+func execv(cmd string, cmdArgs []string) error {
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}

--- a/godotenv.go
+++ b/godotenv.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
@@ -138,11 +137,7 @@ func Unmarshal(str string) (envMap map[string]string, err error) {
 func Exec(filenames []string, cmd string, cmdArgs []string) error {
 	Load(filenames...)
 
-	command := exec.Command(cmd, cmdArgs...)
-	command.Stdin = os.Stdin
-	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
-	return command.Run()
+	return execv(cmd, cmdArgs)
 }
 
 // Write serializes the given environment and writes it to a file
@@ -258,7 +253,7 @@ func parseLine(line string, envMap map[string]string) (key string, value string,
 	}
 	key = strings.TrimSpace(key)
 
-  re := regexp.MustCompile(`^\s*(?:export\s+)?(.*?)\s*$`)
+	re := regexp.MustCompile(`^\s*(?:export\s+)?(.*?)\s*$`)
 	key = re.ReplaceAllString(splitString[0], "$1")
 
 	// Parse the value


### PR DESCRIPTION
Using `syscall.Exec` makes the process tree simpler and is useful when you want the child process to handle the signal.

For example, the `direnv` program internally uses` syscall.Exec`.

https://github.com/direnv/direnv/blob/5b8f7d0ade4248e04899015e8628408b6f4becf3/cmd_exec.go#L67

How about it?