### PR TITLE
Expand variables with existing variables

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -258,7 +258,7 @@ func parseLine(line string, envMap map[string]string) (key string, value string,
 	}
 	key = strings.TrimSpace(key)
 
-  re := regexp.MustCompile(`^\s*(?:export\s+)?(.*?)\s*$`)
+	re := regexp.MustCompile(`^\s*(?:export\s+)?(.*?)\s*$`)
 	key = re.ReplaceAllString(splitString[0], "$1")
 
 	// Parse the value
@@ -323,7 +323,10 @@ func expandVariables(v string, m map[string]string) string {
 		if submatch[1] == "\\" || submatch[2] == "(" {
 			return submatch[0][1:]
 		} else if submatch[4] != "" {
-			return m[submatch[4]]
+			if v, ok := m[submatch[4]]; ok {
+				return v
+			}
+			return os.Getenv(submatch[4])
 		}
 		return s
 	})

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -208,6 +208,8 @@ func TestSubstitutions(t *testing.T) {
 }
 
 func TestExpanding(t *testing.T) {
+	os.Setenv("BAZ", "testbaz")
+
 	tests := []struct {
 		name     string
 		input    string
@@ -252,6 +254,11 @@ func TestExpanding(t *testing.T) {
 			"does not expand escaped variables",
 			"FOO=test\nBAR=\"foo\\${FOO} ${FOO}\"",
 			map[string]string{"FOO": "test", "BAR": "foo${FOO} test"},
+		},
+		{
+			"expands variables with existing ones",
+			"FOO=$BAZ\nBAZ=baz$BAZ\nBAR=$BAZ",
+			map[string]string{"FOO": "testbaz", "BAZ": "baztestbaz", "BAR": "baztestbaz"},
 		},
 	}
 


### PR DESCRIPTION
Hi,

Currently `godotenv` doesn't use existing env variables (defined outside the package) while expanding provided ones. This PR fixes the behavior.