### PR TITLE
Support expands dot variables and add go mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/joho/godotenv
+
+go 1.10

--- a/godotenv.go
+++ b/godotenv.go
@@ -320,7 +320,7 @@ func parseValue(value string, envMap map[string]string) string {
 	return value
 }
 
-var expandVarRegex = regexp.MustCompile(`(\\)?(\$)(\()?\{?([A-Z0-9_]+)?\}?`)
+var expandVarRegex = regexp.MustCompile(`(\\)?(\$)(\()?\{?([A-Z\.0-9_]+)?\}?`)
 
 func expandVariables(v string, m map[string]string) string {
 	return expandVarRegex.ReplaceAllStringFunc(v, func(s string) string {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -219,6 +219,11 @@ func TestExpanding(t *testing.T) {
 			map[string]string{"FOO": "test", "BAR": "test"},
 		},
 		{
+			"expands variables found in dot values",
+			"FOO.BAR=test\nFOO2=${FOO.BAR}",
+			map[string]string{"FOO.BAR": "test", "FOO2": "test"},
+		},
+		{
 			"parses variables wrapped in brackets",
 			"FOO=test\nBAR=${FOO}bar",
 			map[string]string{"FOO": "test", "BAR": "testbar"},


### PR DESCRIPTION
In unit tests varibales with "." in the name is allowed
```
	// it 'parses varibales with "." in the name' do
	// expect(env('FOO.BAR=foobar')).to eql('FOO.BAR' => 'foobar')
	parseAndCompare(t, "FOO.BAR=foobar", "FOO.BAR", "foobar")
```
So, expands should support varibales with "." in the name：

```
FOO.BAR=test
FOO2=${FOO.BAR}
```

And, I added the go mod file. Thanks!