### PR TITLE
proposal: support for optional env files

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -50,6 +50,32 @@ func Load(filenames ...string) (err error) {
 	return
 }
 
+// LoadOpt will *optionally* read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// Loading a file which does not exists will not result in an error
+//
+// If you call LoadOpt without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.LoadOpt("fileone", "filetwo")
+//
+// It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults
+func LoadOpt(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, false)
+		if errors.Is(err, os.ErrNotExist) || err == nil {
+			continue
+		}
+		return err
+	}
+	return nil
+}
+
 // Overload will read your env file(s) and load them into ENV for this process.
 //
 // Call this function as close as possible to the start of your program (ideally in main)
@@ -71,6 +97,32 @@ func Overload(filenames ...string) (err error) {
 		}
 	}
 	return
+}
+
+// OverloadOpt will *optionally* read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// Loading a file which does not exists will not result in an error
+//
+// If you call OverloadOpt without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.OverloadOpt("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+func OverloadOpt(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
+		if errors.Is(err, os.ErrNotExist) || err == nil {
+			continue
+		}
+		return err
+	}
+	return nil
 }
 
 // Read all env (with same file loading semantics as Load) but return values as

--- a/godotenv.go
+++ b/godotenv.go
@@ -68,7 +68,7 @@ func LoadOpt(filenames ...string) (err error) {
 
 	for _, filename := range filenames {
 		err = loadFile(filename, false)
-		if errors.Is(err, os.ErrNotExist) || err == nil {
+		if err != nil && os.IsNotExist(err) {
 			continue
 		}
 		return err
@@ -117,7 +117,7 @@ func OverloadOpt(filenames ...string) (err error) {
 
 	for _, filename := range filenames {
 		err = loadFile(filename, true)
-		if errors.Is(err, os.ErrNotExist) || err == nil {
+		if err != nil && os.IsNotExist(err) {
 			continue
 		}
 		return err

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -470,3 +470,31 @@ func TestRoundtrip(t *testing.T) {
 
 	}
 }
+
+func TestLoadOptWithNoArgs(t *testing.T) {
+	err := LoadOpt(".idnotexist")
+	if err != nil {
+		t.Errorf("Expected '%s' to ignore file '%v' which doesn't exist", "LoadOpt", ".idnotexist")
+	}
+}
+
+func TestLoadOptWithParsingError(t *testing.T) {
+	err := LoadOpt("fixtures/invalid1.env")
+	if err == nil {
+		t.Errorf("Expected '%s' to handle '%v' error", "LoadOpt", "Can't separate key from value")
+	}
+}
+
+func TestOverloadOptOptWithNoArgs(t *testing.T) {
+	err := OverloadOpt(".idnotexist")
+	if err != nil {
+		t.Errorf("Expected '%s' to ignore file '%v' which doesn't exist", "OverloadOpt", ".idnotexist")
+	}
+}
+
+func TestOverloadOptWithParsingError(t *testing.T) {
+	err := OverloadOpt("fixtures/invalid1.env")
+	if err == nil {
+		t.Errorf("Expected '%s' to handle '%v' error", "OverloadOpt", "Can't separate key from value")
+	}
+}


### PR DESCRIPTION
It will be better if there are functions to load env file(s) which just exists and ignore those that doesn't exists. If there are more than one env file. `LoadOpt` and `OverloadOpt` will load the environment from the files that only exists.
Any other error besides `os.ErrNotExists` will be returned appropriately.
```
godotenv.LoadOpt(".env.exists", ".env.doesntexists") // will be fine
godotenv.OverloadOpt(".env.exists", ".env.doesntexists") // will be fine
```