### PR TITLE
Ignore interrupts and wait for child process to exit

### DIFF
--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
+	"os/signal"
 
 	"strings"
 
@@ -43,12 +46,25 @@ example
 		envFilenames = strings.Split(rawEnvFilenames, ",")
 	}
 
+	if err := godotenv.Load(envFilenames...); err != nil {
+		log.Fatal(err)
+	}
+
 	// take rest of args and "exec" them
 	cmd := args[0]
 	cmdArgs := args[1:]
 
-	err := godotenv.Exec(envFilenames, cmd, cmdArgs)
-	if err != nil {
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+
+	signal.Ignore(os.Interrupt)
+	if err := command.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := command.Wait(); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Because signals were not handled, godotenv will sometimes exit before its child process, causing unexpected behavior in some apps. Instead ignore interrupts and just wait for the subprocess to exit. 

fix #21