### PR TITLE
PR_AddingPowerSupport_golang-github-joho-godotenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-arch: amd64
+arch: 
+  - amd64
+  - ppc64le
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+arch: amd64
 language: go
 
 go:


### PR DESCRIPTION
Adding power support ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Please find the Travis link where the build is successful: https://travis-ci.com/github/santosh653/godotenv
The OS "osx" is not supported on power so this job is not picked up for "osx".

Please comment in the comment section if I am missing any other details or if you need any other details.

Thanks you !!