### PR TITLE
Add missing newline to created env files

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -157,7 +157,7 @@ func Write(envMap map[string]string, filename string) error {
 		return err
 	}
 	defer file.Close()
-	_, err = file.WriteString(content)
+	_, err = file.WriteString(content + "\n")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes issue https://github.com/joho/godotenv/issues/132 by adding a newline to created env files.