### PR TITLE
fix: In Parsing expandVariables return unchanged value if not exists in envMap or os-environ

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -337,7 +337,11 @@ func expandVariables(v string, m map[string]string) string {
 		if submatch[1] == "\\" || submatch[2] == "(" {
 			return submatch[0][1:]
 		} else if submatch[4] != "" {
-			return m[submatch[4]]
+			if _, exists := m[submatch[4]]; exists {
+				return m[submatch[4]]
+			} else if len(os.Getenv(submatch[4])) > 0 {
+				return os.Getenv(submatch[4])
+			}
 		}
 		return s
 	})


### PR DESCRIPTION
- [x]  BUG: Variable not correct  (https://github.com/joho/godotenv/issues/127)

With regex expression `(\\)?(\$)(\()?\{?([A-Z0-9_]+)?\}?` https://regex101.com/r/IM10C6/1  any value after $ is treating as variable,
Variable is checked in envMap and return empty string if not found, causing some values to cut down e.g. https://github.com/joho/godotenv/issues/127#issuecomment-787426255
