### PR TITLE
Improve `Can't separate key from value` error message

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -259,7 +259,7 @@ func parseLine(line string, envMap map[string]string) (key string, value string,
 	}
 
 	if len(splitString) != 2 {
-		err = errors.New("Can't separate key from value")
+		err = fmt.Errorf("Can't separate key from value in line `%v`", line)
 		return
 	}
 


### PR DESCRIPTION
Kind of insignificant, but could save some future headaches.

An example: I have a `docker-compose.yml` file with about half a dozen services, each of which has an `env_file`. Docker uses `godotenv` as a dependency to parse these .env files, so when there's an error in any one of these files all I see upon starting the containers is `Can't separate key from value`.

To debug this, I basically have to disable and re-enable the .env files one by one until I've isolated the offending file, and then comb through the file for the offending line.

This MR will reduce some of that effort (and similar efforts) by printing out the line causing parse errors, which can then be used in addition to tools like `grep` for quicker debugging.