### PR TITLE
add basic yaml grammar support

### DIFF
--- a/autoload/autoload.go
+++ b/autoload/autoload.go
@@ -8,7 +8,7 @@ package autoload
 	And bob's your mother's brother
 */
 
-import "github.com/joho/godotenv"
+import "github.com/Jonham/godotenv"
 
 func init() {
 	godotenv.Load()

--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -7,7 +7,7 @@ import (
 
 	"strings"
 
-	"github.com/joho/godotenv"
+	"github.com/Jonham/godotenv"
 )
 
 func main() {

--- a/fixtures/yamlEnv.env.yml
+++ b/fixtures/yamlEnv.env.yml
@@ -1,0 +1,10 @@
+Redis:
+  Env:
+    System: 'MacOS'
+    Disk:
+      Storage:
+        Space: '1GB'
+  Version: '6.2.6'
+  Host: '123.123.123.123'
+  REDIS_HOST_PORT: 12344
+  REDIS_PASSWORD: 'Password'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/joho/godotenv
+module github.com/Jonham/godotenv
 
 go 1.12

--- a/godotenv.go
+++ b/godotenv.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -154,9 +153,7 @@ func Parse(r io.Reader) (envMap map[string]string, err error) {
 			if isYAMLExtensionFile {
 				// handle yaml levels
 				// key with prefix spaces
-				log.Println("pre", key)
 				key = parseYAMLKeyName(key)
-				log.Println("after", key, value)
 			}
 
 			if err != nil {

--- a/godotenv.go
+++ b/godotenv.go
@@ -1,6 +1,6 @@
 // Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
 //
-// Examples/readme can be found on the github page at https://github.com/joho/godotenv
+// Examples/readme can be found on the github page at https://github.com/jonham/godotenv
 //
 // The TL;DR is that you make a .env file that looks something like
 //

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -207,6 +207,20 @@ func TestSubstitutions(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
+func TestYAMLEnv(t *testing.T) {
+	envFileName := "fixtures/yamlEnv.env.yml"
+	expectedValues := map[string]string{
+		"Redis.Version":                "6.2.6",
+		"Redis.Host":                   "123.123.123.123",
+		"Redis.REDIS_HOST_PORT":        "12344",
+		"Redis.REDIS_PASSWORD":         "Password",
+		"Redis.Env.System":             "MacOS",
+		"Redis.Env.Disk.Storage.Space": "1GB",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
 func TestExpanding(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
follow the yaml-syntax, when `env.yaml` input
```yaml
Redis:
  Version: "2.6"
```
you should get `'Redis.Version' -> '2.6'`, NOT `'Version' -> '2.6'`.

The prefix spaces mean level to key and value. There are 2 spaces before Version, means `Version` is the `field` of `Redis`.