### PR TITLE
tune README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ go get github.com/joho/godotenv
 ```
 
 or if you want to use it as a bin command
+go >= 1.17
 ```shell
 go install github.com/joho/godotenv/cmd/godotenv@latest
+```
+
+go < 1.17
+```shell
+go get github.com/joho/godotenv/cmd/godotenv
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get github.com/joho/godotenv
 
 or if you want to use it as a bin command
 ```shell
-go get github.com/joho/godotenv/cmd/godotenv
+go install github.com/joho/godotenv/cmd/godotenv@latest
 ```
 
 ## Usage


### PR DESCRIPTION
```
$ go get github.com/joho/godotenv/cmd/godotenv
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```