### PR TITLE
Fix typos in comments and extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoDotEnv ![CI](https://github.com/joho/godotenv/workflows/CI/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/joho/godotenv)](https://goreportcard.com/report/github.com/joho/godotenv)
 
-A Go (golang) port of the Ruby dotenv project (which loads env vars from a .env file)
+A Go (golang) port of the Ruby [dotenv](https://github.com/bkeepers/dotenv) project (which loads env vars from a .env file).
 
 From the original Library:
 
@@ -8,9 +8,9 @@ From the original Library:
 >
 > But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. Dotenv load variables from a .env file into ENV when the environment is bootstrapped.
 
-It can be used as a library (for loading in env for your own daemons etc) or as a bin command.
+It can be used as a library (for loading in env for your own daemons etc.) or as a bin command.
 
-There is test coverage and CI for both linuxish and windows environments, but I make no guarantees about the bin version working on windows.
+There is test coverage and CI for both linuxish and Windows environments, but I make no guarantees about the bin version working on Windows.
 
 ## Installation
 

--- a/godotenv.go
+++ b/godotenv.go
@@ -1,6 +1,6 @@
 // Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
 //
-// Examples/readme can be found on the github page at https://github.com/joho/godotenv
+// Examples/readme can be found on the GitHub page at https://github.com/joho/godotenv
 //
 // The TL;DR is that you make a .env file that looks something like
 //
@@ -61,7 +61,7 @@ func Load(filenames ...string) (err error) {
 //
 //		godotenv.Overload("fileone", "filetwo")
 //
-// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefully set all vars.
 func Overload(filenames ...string) (err error) {
 	filenames = filenamesOrDefault(filenames)
 

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -131,7 +131,7 @@ func TestLoadDoesNotOverride(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, presets)
 }
 
-func TestOveroadDoesOverride(t *testing.T) {
+func TestOverloadDoesOverride(t *testing.T) {
 	envFileName := "fixtures/plain.env"
 
 	// ensure NO overload
@@ -325,11 +325,11 @@ func TestParsing(t *testing.T) {
 	// expect(env('FOO="bar\nbaz"')).to eql('FOO' => "bar\nbaz")
 	parseAndCompare(t, `FOO="bar\nbaz"`, "FOO", "bar\nbaz")
 
-	// it 'parses varibales with "." in the name' do
+	// it 'parses variables with "." in the name' do
 	// expect(env('FOO.BAR=foobar')).to eql('FOO.BAR' => 'foobar')
 	parseAndCompare(t, "FOO.BAR=foobar", "FOO.BAR", "foobar")
 
-	// it 'parses varibales with several "=" in the value' do
+	// it 'parses variables with several "=" in the value' do
 	// expect(env('FOO=foobar=')).to eql('FOO' => 'foobar=')
 	parseAndCompare(t, "FOO=foobar=", "FOO", "foobar=")
 


### PR DESCRIPTION
This PR:
- fixes typos and grammar issues;
- extends README with the link to Ruby's dotenv;
- fixes typo in test's name.