### PR TITLE
Issue 175: Command does not load dotenv files if some do not exist

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -137,7 +137,9 @@ func Unmarshal(str string) (envMap map[string]string, err error) {
 // If you want more fine grained control over your command it's recommended
 // that you use `Load()` or `Read()` and the `os/exec` package yourself.
 func Exec(filenames []string, cmd string, cmdArgs []string) error {
-	Load(filenames...)
+
+	filteredFilenames := filterFilesNotExist(filenames)
+	Load(filteredFilenames...)
 
 	command := exec.Command(cmd, cmdArgs...)
 	command.Stdin = os.Stdin
@@ -360,4 +362,16 @@ func doubleQuoteEscape(line string) string {
 		line = strings.Replace(line, string(c), toReplace, -1)
 	}
 	return line
+}
+
+func filterFilesNotExist(filenames []string) []string {
+	result := make([]string, 0, len(filenames))
+	for _, fileName := range filenames {
+		if _, err := os.Stat(fileName); err != nil {
+			fmt.Fprintf(os.Stderr, "File: `%s` not found \n", fileName)
+		} else {
+			result = append(result, fileName)
+		}
+	}
+	return result
 }

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -472,3 +472,42 @@ func TestRoundtrip(t *testing.T) {
 
 	}
 }
+
+func Test_filterFilesNotExist(t *testing.T) {
+	type testCase struct {
+		description       string
+		givenFilenames    []string
+		expectedFileNames []string
+	}
+
+	testCases := []testCase{
+		testCase{
+			description: "When all files do exist, then return all",
+			givenFilenames:    []string{"fixtures/equals.env", "fixtures/exported.env"},
+			expectedFileNames: []string{"fixtures/equals.env", "fixtures/exported.env"},
+		},
+		testCase{
+			description: "When none of the files do exist, then return empty slice",
+			givenFilenames:    []string{"not-existed-file.env", "wrong-fileName.env"},
+			expectedFileNames: []string{},
+		},
+		testCase{
+			description: "When some of the files do exist, then filter and return exist files",
+			givenFilenames:    []string{"not-existed-file.env", "wrong-fileName.env", "fixtures/equals.env"},
+			expectedFileNames: []string{"fixtures/equals.env"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		//when
+		actual := filterFilesNotExist(testCase.givenFilenames)
+
+		//then
+		if !reflect.DeepEqual(actual, testCase.expectedFileNames) {
+			t.Error("For", testCase.description,
+				"\n Given: ", testCase.givenFilenames,
+				"\n Expected:", testCase.expectedFileNames,
+				"\n Got", actual)
+		}
+	}
+}


### PR DESCRIPTION
Hi, The following PR is intended to resolve [issue-175](https://github.com/joho/godotenv/issues/175) .

When the any of the passed fileNames do not exist, it just silently stops the process of 'load env files'
and start to execute the command provided.

I believe that behaviour might lead to unexpected results and assumptions which might affect the correctness of the system that utilizes the environment variables using _godotenv_ command
And decided to make small PR.

Current behaviour:
Silently stopping the process of 'load env files' and continuing to execute the command provided.

```
$ cat .env
FOO="Using .env"

$ godotenv -f ".env,.env.doesnotexist" env | grep FOO
FOO=Using .env

$ godotenv -f ".env.doesnotexist,.env" env | grep FOO
# FOO does not get set
```


Considered behaviour: 
When some of the fileNames do not exist, then print the error message: "File: `${fileName}` not found" to stderr
and continue to load the remaining fileNames.
After _the load process_ has been finished, continue to execute command provided.
```
$ cat .env
FOO="Using .env"

$ godotenv -f ".env,.env.doesnotexist" env | grep FOO
FOO=Using .env

$ godotenv -f ".env.doesnotexist,.env" env | grep FOO
File: `.env.doesnotexist` not found
File: `.env` not found
File: `valid.env` not found
...
```