### PR TITLE
add overload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ godotenv -f /some/path/to/.env some_command with some args
 
 If you don't specify `-f` it will fall back on the default of loading `.env` in `PWD`
 
+By default, it won't override existing environment variables; you can do that with the `-o` flag.
+
 ### Writing Env Files
 
 Godotenv can also write a map representing the environment to a correctly-formatted and escaped file

--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -15,13 +15,15 @@ func main() {
 	flag.BoolVar(&showHelp, "h", false, "show help")
 	var rawEnvFilenames string
 	flag.StringVar(&rawEnvFilenames, "f", "", "comma separated paths to .env files")
+	var overload bool
+	flag.BoolVar(&overload, "o", false, "override existing .env variables")
 
 	flag.Parse()
 
 	usage := `
 Run a process with an env setup from a .env file
 
-godotenv [-f ENV_FILE_PATHS] COMMAND_ARGS
+godotenv [-o] [-f ENV_FILE_PATHS] COMMAND_ARGS
 
 ENV_FILE_PATHS: comma separated paths to .env files
 COMMAND_ARGS: command and args you want to run
@@ -47,7 +49,7 @@ example
 	cmd := args[0]
 	cmdArgs := args[1:]
 
-	err := godotenv.Exec(envFilenames, cmd, cmdArgs)
+	err := godotenv.Exec(envFilenames, cmd, cmdArgs, overload)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/godotenv.go
+++ b/godotenv.go
@@ -125,9 +125,13 @@ func UnmarshalBytes(src []byte) (map[string]string, error) {
 // Simply hooks up os.Stdin/err/out to the command and calls Run().
 //
 // If you want more fine grained control over your command it's recommended
-// that you use `Load()` or `Read()` and the `os/exec` package yourself.
-func Exec(filenames []string, cmd string, cmdArgs []string) error {
-	if err := Load(filenames...); err != nil {
+// that you use `Load()`, `Overload()` or `Read()` and the `os/exec` package yourself.
+func Exec(filenames []string, cmd string, cmdArgs []string, overload bool) error {
+	op := Load
+	if overload {
+		op = Overload
+	}
+	if err := op(filenames...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
implements ruby's -o option (https://github.com/bkeepers/dotenv#why-is-it-not-overriding-existing-env-variables).
\---
example
```shell
% cat a.env
VAR=a
% cat b.env
VAR=b
% godotenv -f a.env,b.env printenv VAR
a
% godotenv -o -f a.env,b.env printenv VAR
b
```