### PR TITLE
Fix: ioutil.ReadAll() is deprecated, so removed it's dependency

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -4,20 +4,20 @@
 //
 // The TL;DR is that you make a .env file that looks something like
 //
-// 		SOME_ENV_VAR=somevalue
+//	SOME_ENV_VAR=somevalue
 //
 // and then in your go code you can call
 //
-// 		godotenv.Load()
+//	godotenv.Load()
 //
 // and all the env vars declared in .env will be available through os.Getenv("SOME_ENV_VAR")
 package godotenv
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -30,12 +30,13 @@ const doubleQuoteSpecialChars = "\\\n\r\"!$`"
 
 // Parse reads an env file from io.Reader, returning a map of keys and values.
 func Parse(r io.Reader) (map[string]string, error) {
-	data, err := ioutil.ReadAll(r)
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
 	if err != nil {
 		return nil, err
 	}
 
-	return UnmarshalBytes(data)
+	return UnmarshalBytes(buf.Bytes())
 }
 
 // Load will read your env file(s) and load them into ENV for this process.
@@ -46,7 +47,7 @@ func Parse(r io.Reader) (map[string]string, error) {
 //
 // You can otherwise tell it which files to load (there can be more than one) like:
 //
-//		godotenv.Load("fileone", "filetwo")
+//	godotenv.Load("fileone", "filetwo")
 //
 // It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults.
 func Load(filenames ...string) (err error) {
@@ -69,7 +70,7 @@ func Load(filenames ...string) (err error) {
 //
 // You can otherwise tell it which files to load (there can be more than one) like:
 //
-//		godotenv.Overload("fileone", "filetwo")
+//	godotenv.Overload("fileone", "filetwo")
 //
 // It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefully set all vars.
 func Overload(filenames ...string) (err error) {


### PR DESCRIPTION
As `ioutil.ReadAll()` is deprecated, replaced it with buffer.

```go
var buf bytes.Buffer
_, err := io.Copy(&buf, r)
```

Changes
```patch
diff --git a/godotenv.go b/godotenv.go
index 368e804..fd48c6a 100644
--- a/godotenv.go
+++ b/godotenv.go
@@ -4,20 +4,20 @@
 //
 // The TL;DR is that you make a .env file that looks something like
 //
-// 		SOME_ENV_VAR=somevalue
+//	SOME_ENV_VAR=somevalue
 //
 // and then in your go code you can call
 //
-// 		godotenv.Load()
+//	godotenv.Load()
 //
 // and all the env vars declared in .env will be available through os.Getenv("SOME_ENV_VAR")
 package godotenv
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -30,12 +30,13 @@ const doubleQuoteSpecialChars = "\\\n\r\"!$`"
 
 // Parse reads an env file from io.Reader, returning a map of keys and values.
 func Parse(r io.Reader) (map[string]string, error) {
-	data, err := ioutil.ReadAll(r)
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
 	if err != nil {
 		return nil, err
 	}
 
-	return UnmarshalBytes(data)
+	return UnmarshalBytes(buf.Bytes())
 }
 
 // Load will read your env file(s) and load them into ENV for this process.
@@ -46,7 +47,7 @@ func Parse(r io.Reader) (map[string]string, error) {
 //
 // You can otherwise tell it which files to load (there can be more than one) like:
 //
-//		godotenv.Load("fileone", "filetwo")
+//	godotenv.Load("fileone", "filetwo")
 //
 // It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults.
 func Load(filenames ...string) (err error) {
@@ -69,7 +70,7 @@ func Load(filenames ...string) (err error) {
 //
 // You can otherwise tell it which files to load (there can be more than one) like:
 //
-//		godotenv.Overload("fileone", "filetwo")
+//	godotenv.Overload("fileone", "filetwo")
 //
 // It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefully set all vars.
 func Overload(filenames ...string) (err error) {
```