### PR TITLE
Add whitespace tests.

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -573,3 +573,64 @@ func TestTrailingNewlines(t *testing.T) {
 		})
 	}
 }
+
+func TestWhitespace(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		key   string
+		value string
+	}{
+		"Leading whitespace": {
+			input: " A=a\n",
+			key: "A",
+			value: "a",
+		},
+		"Leading tab": {
+			input: "\tA=a\n",
+			key: "A",
+			value: "a",
+		},
+		"Leading mixed whitespace": {
+			input: " \t \t\n\t \t A=a\n",
+			key: "A",
+			value: "a",
+		},
+		"Leading whitespace before export": {
+			input: " \t\t export    A=a\n",
+			key: "A",
+			value: "a",
+		},
+		"Trailing whitespace": {
+			input: "A=a \t \t\n",
+			key: "A",
+			value: "a",
+		},
+		"Trailing whitespace with export": {
+			input: "export A=a\t \t \n",
+			key: "A",
+			value: "a",
+		},
+		"No EOL": {
+			input: "A=a",
+			key: "A",
+			value: "a",
+		},
+		"Trailing whitespace with no EOL": {
+			input: "A=a ",
+			key: "A",
+			value: "a",
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			result, err := Unmarshal(c.input)
+			if err != nil {
+				t.Errorf("Input: %q Unexpected error:\t%q", c.input, err)
+			}
+			if result[c.key] != c.value {
+				t.Errorf("Input %q Expected:\t %q/%q\nGot:\t %q", c.input, c.key, c.value, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I confused myself into thinking that godotenv wasn't handling whitespace properly, so I wrote these tests. It turns out, it was handling whitespace just fine, and the mistake was mine. It seems like this PR isn't necessary, but here it is anyway in case you want more tests.