### PR TITLE
Fix panic because of wrong function

### DIFF
--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -35,7 +34,7 @@ example
 	// print usage and return
 	args := flag.Args()
 	if showHelp || len(args) == 0 {
-		fmt.log(usage)
+		fmt.Println(usage)
 		return
 	}
 


### PR DESCRIPTION
Fix the issue caused by the PR https://github.com/joho/godotenv/pull/221, which calls the wrong function in the `fmt` package