### PR TITLE
bugfix: fix an int parsing bug in godotenv.Marshal

### DIFF
--- a/godotenv.go
+++ b/godotenv.go
@@ -21,7 +21,6 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
-	"unicode"
 )
 
 const doubleQuoteSpecialChars = "\\\n\r\"!$`"
@@ -167,9 +166,10 @@ func isInt(s string) bool {
 	}
 
 	for _, r := range s {
-		if !unicode.IsDigit(r) {
-			return false
-		}
+        if '0' <= r && r <= '9' {
+            continue
+        }
+        return false
 	}
 
 	return true

--- a/godotenv.go
+++ b/godotenv.go
@@ -19,8 +19,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -163,9 +163,10 @@ func Write(envMap map[string]string, filename string) error {
 // Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
 func Marshal(envMap map[string]string) (string, error) {
 	lines := make([]string, 0, len(envMap))
+    var isInt = regexp.MustCompile(`^[0-9]+$`).MatchString
 	for k, v := range envMap {
-		if d, err := strconv.Atoi(v); err == nil {
-			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
+		if isInt(v) {
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, v))
 		} else {
 			lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))
 		}

--- a/godotenv.go
+++ b/godotenv.go
@@ -19,9 +19,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 const doubleQuoteSpecialChars = "\\\n\r\"!$`"
@@ -159,11 +159,26 @@ func Write(envMap map[string]string, filename string) error {
 	return file.Sync()
 }
 
+func isInt(s string) bool {
+    if len(s) == 0 {
+		return false
+	} else if s[0] == '-' {
+		s = s[1:]
+	}
+
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Marshal outputs the given environment as a dotenv-formatted environment file.
 // Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
 func Marshal(envMap map[string]string) (string, error) {
 	lines := make([]string, 0, len(envMap))
-    var isInt = regexp.MustCompile(`^[0-9]+$`).MatchString
 	for k, v := range envMap {
 		if isInt(v) {
 			lines = append(lines, fmt.Sprintf(`%s=%s`, k, v))

--- a/godotenv.go
+++ b/godotenv.go
@@ -160,10 +160,10 @@ func Write(envMap map[string]string, filename string) error {
 }
 
 func isInt(s string) bool {
+    s = strings.TrimPrefix(s, "-")
+
     if len(s) == 0 {
 		return false
-	} else if s[0] == '-' {
-		s = s[1:]
 	}
 
 	for _, r := range s {

--- a/godotenv.go
+++ b/godotenv.go
@@ -158,18 +158,21 @@ func Write(envMap map[string]string, filename string) error {
 	return file.Sync()
 }
 
+// isInt checks if the string may be serialized as a number value, leading
+// "-" symbol is allowed for negative numbers, leading "+" sign is not. The
+// length of the value is not limited.
 func isInt(s string) bool {
-    s = strings.TrimPrefix(s, "-")
+	s = strings.TrimPrefix(s, "-")
 
-    if len(s) == 0 {
+	if len(s) == 0 {
 		return false
 	}
 
 	for _, r := range s {
-        if '0' <= r && r <= '9' {
-            continue
-        }
-        return false
+		if '0' <= r && r <= '9' {
+			continue
+		}
+		return false
 	}
 
 	return true

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -499,6 +499,8 @@ func TestIsInt(t *testing.T) {
 	// valid values
 	checkAndCompare("-123", true)
 	checkAndCompare("123", true)
+	checkAndCompare("-922337203685477580868712", true)
+	checkAndCompare("922337203685477580837281", true)
 }
 
 func TestWrite(t *testing.T) {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -493,6 +493,8 @@ func TestIsInt(t *testing.T) {
     checkAndCompare("12a3", false)
     checkAndCompare("abc", false)
     checkAndCompare("12 3", false)
+    checkAndCompare("-", false)
+    checkAndCompare(" ", false)
 
     // valid values
     checkAndCompare("-123", true)

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -480,25 +480,25 @@ func TestComments(t *testing.T) {
 }
 
 func TestIsInt(t *testing.T) {
-    checkAndCompare := func(s string, expected bool) {
-        if isInt(s) != expected {
-            t.Fail()
-        }
-    }
+	checkAndCompare := func(s string, expected bool) {
+		if isInt(s) != expected {
+			t.Fail()
+		}
+	}
 
-    // invalid values
-    checkAndCompare("", false)
-    checkAndCompare("+123", false)
-    checkAndCompare("+12a3", false)
-    checkAndCompare("12a3", false)
-    checkAndCompare("abc", false)
-    checkAndCompare("12 3", false)
-    checkAndCompare("-", false)
-    checkAndCompare(" ", false)
+	// invalid values
+	checkAndCompare("", false)
+	checkAndCompare("+123", false)
+	checkAndCompare("+12a3", false)
+	checkAndCompare("12a3", false)
+	checkAndCompare("abc", false)
+	checkAndCompare("12 3", false)
+	checkAndCompare("-", false)
+	checkAndCompare(" ", false)
 
-    // valid values
-    checkAndCompare("-123", true)
-    checkAndCompare("123", true)
+	// valid values
+	checkAndCompare("-123", true)
+	checkAndCompare("123", true)
 }
 
 func TestWrite(t *testing.T) {
@@ -604,42 +604,42 @@ func TestWhitespace(t *testing.T) {
 	}{
 		"Leading whitespace": {
 			input: " A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading tab": {
 			input: "\tA=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading mixed whitespace": {
 			input: " \t \t\n\t \t A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading whitespace before export": {
 			input: " \t\t export    A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace": {
 			input: "A=a \t \t\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace with export": {
 			input: "export A=a\t \t \n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"No EOL": {
 			input: "A=a",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace with no EOL": {
 			input: "A=a ",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 	}

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -479,6 +479,26 @@ func TestComments(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
+func TestIsInt(t *testing.T) {
+    checkAndCompare := func(s string, expected bool) {
+        if isInt(s) != expected {
+            t.Fail()
+        }
+    }
+
+    // invalid values
+    checkAndCompare("", false)
+    checkAndCompare("+123", false)
+    checkAndCompare("+12a3", false)
+    checkAndCompare("12a3", false)
+    checkAndCompare("abc", false)
+    checkAndCompare("12 3", false)
+
+    // valid values
+    checkAndCompare("-123", true)
+    checkAndCompare("123", true)
+}
+
 func TestWrite(t *testing.T) {
 	writeAndCompare := func(env string, expected string) {
 		envMap, _ := Unmarshal(env)


### PR DESCRIPTION
If you encounter a value like `+1234567890`, in my case it was a phone number, the `strconv.Atoi` will actually remove the `+` sign and won't throw an error.

That's how it looks like:
```
x, err := strconv.Atoi(`+123456789`)
fmt.Println(err)
fmt.Println(x)
```
```
<nil>
123456789
```

Additionally, if you have a very long value, the `strconv.Atoi` will throw an error: `value out of range`, which is correct, but we shouldn't care, it's all numbers - just store it. And when reading back we get all values in `string` anyway.

Of course, in the case of godotenv this behavior may cause some issues (it did in my case), you can see my proposition for a fix in the commit.

After the change, only values containing numbers and nothing else will be treated as integers (without quotes), everything else will be in quotations.

Though using regex is not the most optimal solution, it was the first one, that came to me (and it's quite concise), but of course, it could be replaced with a better solution.