### PR TITLE
fix: if a line contains multiple # characters, there will be issues w…

### DIFF
--- a/fixtures/comments.env
+++ b/fixtures/comments.env
@@ -1,4 +1,6 @@
 # Full line comment
+qux=thud # fred # other
+thud=fred#qux # other
 foo=bar # baz
 bar=foo#baz
 baz="foo"#bar

--- a/fixtures/comments.env
+++ b/fixtures/comments.env
@@ -1,6 +1,7 @@
 # Full line comment
 qux=thud # fred # other
 thud=fred#qux # other
+fred=qux#baz # other # more
 foo=bar # baz
 bar=foo#baz
 baz="foo"#bar

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -479,6 +479,7 @@ func TestComments(t *testing.T) {
 	expectedValues := map[string]string{
 		"qux":  "thud",
 		"thud": "fred#qux",
+		"fred": "qux#baz",
 		"foo":  "bar",
 		"bar":  "foo#baz",
 		"baz":  "foo",

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -477,9 +477,11 @@ func TestErrorParsing(t *testing.T) {
 func TestComments(t *testing.T) {
 	envFileName := "fixtures/comments.env"
 	expectedValues := map[string]string{
-		"foo": "bar",
-		"bar": "foo#baz",
-		"baz": "foo",
+		"qux":  "thud",
+		"thud": "fred#qux",
+		"foo":  "bar",
+		"bar":  "foo#baz",
+		"baz":  "foo",
 	}
 
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
@@ -588,42 +590,42 @@ func TestWhitespace(t *testing.T) {
 	}{
 		"Leading whitespace": {
 			input: " A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading tab": {
 			input: "\tA=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading mixed whitespace": {
 			input: " \t \t\n\t \t A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Leading whitespace before export": {
 			input: " \t\t export    A=a\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace": {
 			input: "A=a \t \t\n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace with export": {
 			input: "export A=a\t \t \n",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"No EOL": {
 			input: "A=a",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 		"Trailing whitespace with no EOL": {
 			input: "A=a ",
-			key: "A",
+			key:   "A",
 			value: "a",
 		},
 	}

--- a/parser.go
+++ b/parser.go
@@ -143,9 +143,9 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 		}
 
 		// Work backwards to check if the line ends in whitespace then
-		// a comment (ie asdasd # some comment)
-		for i := endOfVar - 1; i >= 0; i-- {
-			if line[i] == charComment && i > 0 {
+		// a comment (ie asdasd # some comment # other)
+		for i := 0; i < endOfVar; i++ {
+			if line[i] == charComment && i < endOfVar {
 				if isSpace(line[i-1]) {
 					endOfVar = i
 					break

--- a/parser.go
+++ b/parser.go
@@ -143,7 +143,7 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 		}
 
 		// Work backwards to check if the line ends in whitespace then
-		// a comment (ie asdasd # some comment # other)
+		// a comment, ie: foo=bar # baz # other
 		for i := 0; i < endOfVar; i++ {
 			if line[i] == charComment && i < endOfVar {
 				if isSpace(line[i-1]) {


### PR DESCRIPTION
When traversing from back to front, an error occurs if a line contains multiple # characters, such as bar=foo # baz # other. I changed it to traverse from front to back instead.