### PR TITLE
Fix Precedence & Conventions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ if "" == env {
   env = "development"
 }
 
-godotenv.Load(".env." + env + ".local")
+godotenv.Load() // The Original .env
+godotenv.Load(".env." + env)
 if "test" != env {
   godotenv.Load(".env.local")
 }
-godotenv.Load(".env." + env)
-godotenv.Load() // The Original .env
+godotenv.Load(".env." + env + ".local")
 ```
 
 If you need to, you can also use `godotenv.Overload()` to defy this convention


### PR DESCRIPTION
Following the [docs](https://github.com/bkeepers/dotenv?tab=readme-ov-file#customizing-rails) in the original ruby repo, the loading order should be the opposite. The existing example in the readme is confusing, but this PR fix that