### PR TITLE
Fixed backwards compatibility with godotenv 1.4.0 allowing hyphens in variable names.

### DIFF
--- a/fixtures/hyphen.env
+++ b/fixtures/hyphen.env
@@ -1,0 +1,3 @@
+OPTION_A=abc
+OPTION-B=def
+

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -184,6 +184,16 @@ func TestLoadEqualsEnv(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
+func TestLoadHyphenEnv(t *testing.T) {
+	envFileName := "fixtures/hyphen.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "abc",
+		"OPTION-B": "def",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
 func TestLoadQuotedEnv(t *testing.T) {
 	envFileName := "fixtures/quoted.env"
 	expectedValues := map[string]string{

--- a/parser.go
+++ b/parser.go
@@ -96,8 +96,8 @@ loop:
 			break loop
 		case '_':
 		default:
-			// variable name should match [A-Za-z0-9_.]
-			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) || rchar == '.' {
+			// variable name should match [A-Za-z0-9_.-]
+			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) || rchar == '.' || rchar == '-' {
 				continue
 			}
 


### PR DESCRIPTION
Version 1.4.0 allowed hyphen "-" to be in environment variable names, after 1.4.0 this resulted in a parsing error which breaks backwards compatibility.  Added back in hyphen support in variable names with associated test cases.  While hyphen may not be supported everywhere, it is supported in most OS distributions.