### PR TITLE
Add ReadNoExpand based on v1.5.1

### DIFF
--- a/autoload/autoload.go
+++ b/autoload/autoload.go
@@ -3,12 +3,12 @@ package autoload
 /*
 	You can just read the .env file on import just by doing
 
-		import _ "github.com/joho/godotenv/autoload"
+		import _ "github.com/emergentbase/godotenv/autoload"
 
 	And bob's your mother's brother
 */
 
-import "github.com/joho/godotenv"
+import "github.com/emergentbase/godotenv"
 
 func init() {
 	godotenv.Load()

--- a/cmd/godotenv/cmd.go
+++ b/cmd/godotenv/cmd.go
@@ -7,7 +7,7 @@ import (
 
 	"strings"
 
-	"github.com/joho/godotenv"
+	"github.com/emergentbase/godotenv"
 )
 
 func main() {

--- a/edge_cases_test.go
+++ b/edge_cases_test.go
@@ -1,0 +1,105 @@
+package godotenv
+
+import (
+	"testing"
+)
+
+func TestEdgeCases(t *testing.T) {
+	envs, err := ReadNoExpand("testdata/edge_cases.env")
+	if err != nil {
+		t.Fatalf("ReadNoExpand failed: %v", err)
+	}
+
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		// Basic values
+		{"SIMPLE", "hello"},
+		{"EMPTY_VALUE", ""},
+		{"WITH_SPACES", "hello world"},
+
+		// The bug: values starting with #
+		{"HASH_VALUE", "#value"},
+		{"COLOR", "#ff0000"},
+		{"HEX_COLOR", "#333"},
+		{"ANCHOR", "#section-1"},
+		{"CHANNEL", "#general"},
+
+		// Hash inside values
+		{"URL", "https://example.com/page#anchor"},
+		{"HASH_MID", "before#after"},
+		{"HASH_WITH_SPACE", "value"},  // " # this is a comment" stripped
+		{"MULTI_HASH", "foo#bar#baz"}, // no space before #, so not a comment
+
+		// Quoted values with hashes
+		{"SINGLE_QUOTED", "#not-a-comment"},
+		{"DOUBLE_QUOTED", "#also-not-a-comment"},
+		{"QUOTED_WITH_SPACE", "value # not stripped"},
+
+		// Numeric and special values
+		{"PORT", "8080"},
+		{"FLOAT", "3.14"},
+		{"NEGATIVE", "-1"},
+		{"ZERO", "0"},
+		{"BOOLEAN_TRUE", "true"},
+		{"BOOLEAN_FALSE", "false"},
+
+		// URLs and connection strings
+		{"DATABASE_URL", "postgres://user:pass@host:5432/db"},
+		{"MONGO_URL", "mongodb+srv://user:pass@cluster.mongodb.net/"},
+		{"REDIS_URL", "redis://localhost:6379"},
+		{"API_URL", "https://api.example.com/v1"},
+
+		// Special characters
+		{"WITH_EQUALS", "key=value"},
+		{"WITH_COLON", "host:port"},
+		{"WITH_AT", "user@domain.com"},
+		{"WITH_BANG", "hello!"},
+		{"WITH_DOLLAR", "price$100"},
+		{"WITH_PERCENT", "100%"},
+		{"WITH_AMPERSAND", "a&b"},
+		{"WITH_PIPE", "a|b"},
+		{"WITH_PARENS", "(hello)"},
+		{"WITH_BRACKETS", "[1,2,3]"},
+		{"WITH_BRACES", "{key:val}"},
+		{"WITH_BACKTICK", "`code`"},
+		{"WITH_TILDE", "~/path"},
+		{"WITH_CARET", "a^b"},
+
+		// Whitespace edge cases
+		{"LEADING_SPACE", "hello"},
+		{"TRAILING_SPACE", "hello"},
+		{"TABS", "tabbed\tvalue"},
+
+		// Empty-ish values
+		{"JUST_HASH", "#"},
+		{"JUST_SPACE", ""},
+		{"DOUBLE_HASH", "##double"},
+
+		// Long values
+		{"LONG_VALUE", "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"},
+
+		// Multi-word with hash comment
+		{"SENTENCE", "the quick brown fox"}, // " # jumps over" is a comment
+		{"NOSPACE_HASH", "foo#bar"},         // no space before #, not a comment
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got, ok := envs[tt.key]
+			if !ok {
+				t.Fatalf("key %q not found in parsed envs", tt.key)
+			}
+			if got != tt.expected {
+				t.Errorf("key %q: got %q, want %q", tt.key, got, tt.expected)
+			}
+		})
+	}
+
+	// Also verify total count to catch unexpected extra keys
+	t.Logf("Total keys parsed: %d", len(envs))
+	for k, v := range envs {
+		t.Logf("  %s=%q", k, v)
+	}
+}

--- a/fixtures/noexpand.env
+++ b/fixtures/noexpand.env
@@ -1,0 +1,46 @@
+SIMPLE=value
+SINGLE_QUOTED='single quoted value'
+DOUBLE_QUOTED="double quoted value"
+EMPTY_VALUE=
+EMPTY_SINGLE=''
+EMPTY_DOUBLE=""
+
+# Dollar signs that would normally be expanded
+DOLLAR_UNQUOTED=$12345$vrimcongri$^%$#$12345
+DOLLAR_DOUBLE="$12345$vrimcongri$^%$#$12345"
+DOLLAR_SINGLE='$12345$vrimcongri$^%$#$12345'
+
+# Variable-like patterns
+VAR_REF=$FOO
+VAR_BRACKET=${FOO}
+VAR_MIXED=prefix$FOO_suffix
+VAR_DOUBLE="prefix$FOO_suffix"
+
+# Special characters in values
+MONGO_URL=mongodb+srv://user:p@ss%40w0rd@cluster.mongodb.net/dbname
+API_KEY='C1FVs#$%NAQQQ@J'
+CONNECTION_STRING="postgresql://user:pass@host:5432/db?sslmode=disable"
+CORS_ORIGINS=https://example.com,https://other.com
+
+# Comments
+VALUE_WITH_HASH=value#nospace
+VALUE_WITH_HASH_SPACE=value # this is a comment
+
+# Escaped newlines in double quotes
+MULTILINE_ESCAPED="line1\nline2\nline3"
+
+# Multi-line values in single quotes
+PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA
+-----END RSA PRIVATE KEY-----'
+
+# Multi-line values in double quotes
+CERT="-----BEGIN CERT-----
+ABCDEF
+-----END CERT-----"
+
+# Export prefix
+export EXPORTED_VAR=exported_value
+
+# Equals in value
+DATABASE_URL=postgres://localhost:5432/database?sslmode=disable

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/joho/godotenv
+module github.com/emergentbase/godotenv
 
 go 1.12

--- a/godotenv.go
+++ b/godotenv.go
@@ -90,7 +90,7 @@ func Read(filenames ...string) (envMap map[string]string, err error) {
 	envMap = make(map[string]string)
 
 	for _, filename := range filenames {
-		individualEnvMap, individualErr := readFile(filename)
+		individualEnvMap, individualErr := readFile(filename, false)
 
 		if individualErr != nil {
 			err = individualErr
@@ -113,9 +113,31 @@ func Unmarshal(str string) (envMap map[string]string, err error) {
 // UnmarshalBytes parses env file from byte slice of chars, returning a map of keys and values.
 func UnmarshalBytes(src []byte) (map[string]string, error) {
 	out := make(map[string]string)
-	err := parseBytes(src, out)
+	err := parseBytes(src, out, false)
 
 	return out, err
+}
+
+// ReadNoExpand is like Read but does not expand variable references ($VAR, ${VAR}).
+// Values containing dollar signs are preserved as-is.
+func ReadNoExpand(filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(filename, true)
+
+		if individualErr != nil {
+			err = individualErr
+			return
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
 }
 
 // Exec loads env vars from the specified filenames (empty map falls back to default)
@@ -182,7 +204,7 @@ func filenamesOrDefault(filenames []string) []string {
 }
 
 func loadFile(filename string, overload bool) error {
-	envMap, err := readFile(filename)
+	envMap, err := readFile(filename, false)
 	if err != nil {
 		return err
 	}
@@ -203,14 +225,22 @@ func loadFile(filename string, overload bool) error {
 	return nil
 }
 
-func readFile(filename string) (envMap map[string]string, err error) {
+func readFile(filename string, noExpand bool) (envMap map[string]string, err error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return
 	}
 	defer file.Close()
 
-	return Parse(file)
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, file)
+	if err != nil {
+		return
+	}
+
+	out := make(map[string]string)
+	err = parseBytes(buf.Bytes(), out, noExpand)
+	return out, err
 }
 
 func doubleQuoteEscape(line string) string {

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -509,7 +509,7 @@ func TestRoundtrip(t *testing.T) {
 	fixtures := []string{"equals.env", "exported.env", "plain.env", "quoted.env"}
 	for _, fixture := range fixtures {
 		fixtureFilename := fmt.Sprintf("fixtures/%s", fixture)
-		env, err := readFile(fixtureFilename)
+		env, err := readFile(fixtureFilename, false)
 		if err != nil {
 			t.Errorf("Expected '%s' to read without error (%v)", fixtureFilename, err)
 		}

--- a/noexpand_test.go
+++ b/noexpand_test.go
@@ -1,0 +1,153 @@
+package godotenv
+
+import (
+	"testing"
+)
+
+func TestNoExpandDollarSigns(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			"preserves dollar signs in unquoted values",
+			"TWILIO_SECRET=$12345$vrimcongri$^%$#$12345",
+			map[string]string{"TWILIO_SECRET": "$12345$vrimcongri$^%$#$12345"},
+		},
+		{
+			"preserves dollar signs in double quoted values",
+			`TWILIO_SECRET="$12345$vrimcongri$^%$#$12345"`,
+			map[string]string{"TWILIO_SECRET": "$12345$vrimcongri$^%$#$12345"},
+		},
+		{
+			"preserves dollar signs in single quoted values",
+			"TWILIO_SECRET='$12345$vrimcongri$^%$#$12345'",
+			map[string]string{"TWILIO_SECRET": "$12345$vrimcongri$^%$#$12345"},
+		},
+		{
+			"preserves $VAR references",
+			"BAR=$FOO",
+			map[string]string{"BAR": "$FOO"},
+		},
+		{
+			"preserves ${VAR} references",
+			"BAR=${FOO}bar",
+			map[string]string{"BAR": "${FOO}bar"},
+		},
+		{
+			"preserves $VAR in double quoted values",
+			`BAR="quote $FOO"`,
+			map[string]string{"BAR": "quote $FOO"},
+		},
+		{
+			"does not cross-reference variables",
+			"FOO=test\nBAR=$FOO",
+			map[string]string{"FOO": "test", "BAR": "$FOO"},
+		},
+		{
+			"preserves multiple variable patterns",
+			"DATABASE_URL=$HOST:$PORT/$DBNAME",
+			map[string]string{"DATABASE_URL": "$HOST:$PORT/$DBNAME"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := make(map[string]string)
+			if err := parseBytes([]byte(tt.input), out, true); err != nil {
+				t.Fatalf("Error: %s", err.Error())
+			}
+			for k, v := range tt.expected {
+				if out[k] != v {
+					t.Errorf("Key %s: expected %q, got %q", k, v, out[k])
+				}
+			}
+		})
+	}
+}
+
+func TestNoExpandPreservesOtherBehavior(t *testing.T) {
+	parse := func(input, key, expected string) {
+		t.Helper()
+		out := make(map[string]string)
+		if err := parseBytes([]byte(input), out, true); err != nil {
+			t.Errorf("Input %q errored: %v", input, err)
+			return
+		}
+		if out[key] != expected {
+			t.Errorf("Input %q: expected %q=%q, got %q", input, key, expected, out[key])
+		}
+	}
+
+	parse("FOO=bar", "FOO", "bar")
+	parse(`FOO="bar"`, "FOO", "bar")
+	parse("FOO='bar'", "FOO", "bar")
+	parse(`FOO="escaped\"bar"`, "FOO", `escaped"bar`)
+	parse("FOO=bar ", "FOO", "bar")
+	parse("KEY=value value", "KEY", "value value")
+	parse("FOO=bar # comment", "FOO", "bar")
+	parse(`FOO="bar#baz"`, "FOO", "bar#baz")
+	parse("export OPTION_A=2", "OPTION_A", "2")
+	parse(`FOO="bar\nbaz"`, "FOO", "bar\nbaz")
+	parse("FOO.BAR=foobar", "FOO.BAR", "foobar")
+	parse("FOO=foobar=", "FOO", "foobar=")
+	parse("FOO=", "FOO", "")
+}
+
+func TestNoExpandWithFile(t *testing.T) {
+	envMap, err := ReadNoExpand("fixtures/noexpand.env")
+	if err != nil {
+		t.Fatalf("Error reading file: %v", err)
+	}
+
+	expected := map[string]string{
+		"SIMPLE":              "value",
+		"SINGLE_QUOTED":       "single quoted value",
+		"DOUBLE_QUOTED":       "double quoted value",
+		"EMPTY_VALUE":         "",
+		"DOLLAR_UNQUOTED":     "$12345$vrimcongri$^%$#$12345",
+		"DOLLAR_DOUBLE":       "$12345$vrimcongri$^%$#$12345",
+		"DOLLAR_SINGLE":       "$12345$vrimcongri$^%$#$12345",
+		"VAR_REF":             "$FOO",
+		"VAR_BRACKET":         "${FOO}",
+		"MONGO_URL":           "mongodb+srv://user:p@ss%40w0rd@cluster.mongodb.net/dbname",
+		"API_KEY":             "C1FVs#$%NAQQQ@J",
+		"CONNECTION_STRING":   "postgresql://user:pass@host:5432/db?sslmode=disable",
+		"MULTILINE_ESCAPED":   "line1\nline2\nline3",
+		"PRIVATE_KEY":         "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----",
+		"EXPORTED_VAR":        "exported_value",
+		"DATABASE_URL":        "postgres://localhost:5432/database?sslmode=disable",
+		"VALUE_WITH_HASH":     "value#nospace",
+		"VALUE_WITH_HASH_SPACE": "value",
+	}
+
+	for key, want := range expected {
+		got, ok := envMap[key]
+		if !ok {
+			t.Errorf("Key %q not found", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("Key %q: expected %q, got %q", key, want, got)
+		}
+	}
+}
+
+func TestNoExpandOriginalBugScenario(t *testing.T) {
+	input := []byte(`TWILIO_SECRET=$12345$vrimcongri$^%$#$12345`)
+
+	// Default (expansion ON) — corrupts the value
+	expanded := make(map[string]string)
+	parseBytes(input, expanded, false)
+	if expanded["TWILIO_SECRET"] != "$vrimcongri$^%$#" {
+		t.Errorf("Default parse: expected corrupted value, got %q", expanded["TWILIO_SECRET"])
+	}
+
+	// NoExpand — preserves the value
+	raw := make(map[string]string)
+	parseBytes(input, raw, true)
+	if raw["TWILIO_SECRET"] != "$12345$vrimcongri$^%$#$12345" {
+		t.Errorf("NoExpand parse: expected literal value, got %q", raw["TWILIO_SECRET"])
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -17,7 +17,7 @@ const (
 	exportPrefix = "export"
 )
 
-func parseBytes(src []byte, out map[string]string) error {
+func parseBytes(src []byte, out map[string]string, noExpand bool) error {
 	src = bytes.Replace(src, []byte("\r\n"), []byte("\n"), -1)
 	cutset := src
 	for {
@@ -32,7 +32,7 @@ func parseBytes(src []byte, out map[string]string) error {
 			return err
 		}
 
-		value, left, err := extractVarValue(left, out)
+		value, left, err := extractVarValue(left, out, noExpand)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ loop:
 }
 
 // extractVarValue extracts variable value and returns rest of slice
-func extractVarValue(src []byte, vars map[string]string) (value string, rest []byte, err error) {
+func extractVarValue(src []byte, vars map[string]string, noExpand bool) (value string, rest []byte, err error) {
 	quote, hasPrefix := hasQuotePrefix(src)
 	if !hasPrefix {
 		// unquoted value - read until end of line
@@ -154,6 +154,9 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 
 		trimmed := strings.TrimFunc(string(line[0:endOfVar]), isSpace)
 
+		if noExpand {
+			return trimmed, src[endOfLine:], nil
+		}
 		return expandVariables(trimmed, vars), src[endOfLine:], nil
 	}
 
@@ -172,9 +175,13 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 		trimFunc := isCharFunc(rune(quote))
 		value = string(bytes.TrimLeftFunc(bytes.TrimRightFunc(src[0:i], trimFunc), trimFunc))
 		if quote == prefixDoubleQuote {
-			// unescape newlines for double quote (this is compat feature)
-			// and expand environment variables
-			value = expandVariables(expandEscapes(value), vars)
+			if noExpand {
+				value = expandEscapes(value)
+			} else {
+				// unescape newlines for double quote (this is compat feature)
+				// and expand environment variables
+				value = expandVariables(expandEscapes(value), vars)
+			}
 		}
 
 		return value, src[i+1:], nil

--- a/testdata/edge_cases.env
+++ b/testdata/edge_cases.env
@@ -1,0 +1,69 @@
+# === Basic values ===
+SIMPLE=hello
+EMPTY_VALUE=
+WITH_SPACES=hello world
+
+# === The bug: values starting with # ===
+HASH_VALUE=#value
+COLOR=#ff0000
+HEX_COLOR=#333
+ANCHOR=#section-1
+CHANNEL=#general
+
+# === Hash inside values ===
+URL=https://example.com/page#anchor
+HASH_MID=before#after
+HASH_WITH_SPACE=value # this is a comment
+MULTI_HASH=foo#bar#baz
+
+# === Quoted values with hashes ===
+SINGLE_QUOTED='#not-a-comment'
+DOUBLE_QUOTED="#also-not-a-comment"
+QUOTED_WITH_SPACE="value # not stripped"
+
+# === Numeric and special values ===
+PORT=8080
+FLOAT=3.14
+NEGATIVE=-1
+ZERO=0
+BOOLEAN_TRUE=true
+BOOLEAN_FALSE=false
+
+# === URLs and connection strings ===
+DATABASE_URL=postgres://user:pass@host:5432/db
+MONGO_URL=mongodb+srv://user:pass@cluster.mongodb.net/
+REDIS_URL=redis://localhost:6379
+API_URL=https://api.example.com/v1
+
+# === Special characters ===
+WITH_EQUALS=key=value
+WITH_COLON=host:port
+WITH_AT=user@domain.com
+WITH_BANG=hello!
+WITH_DOLLAR=price$100
+WITH_PERCENT=100%
+WITH_AMPERSAND=a&b
+WITH_PIPE=a|b
+WITH_PARENS=(hello)
+WITH_BRACKETS=[1,2,3]
+WITH_BRACES={key:val}
+WITH_BACKTICK=`code`
+WITH_TILDE=~/path
+WITH_CARET=a^b
+
+# === Whitespace edge cases ===
+LEADING_SPACE= hello
+TRAILING_SPACE=hello
+TABS=	tabbed	value
+
+# === Empty-ish values ===
+JUST_HASH=#
+JUST_SPACE=
+DOUBLE_HASH=##double
+
+# === Long values ===
+LONG_VALUE=abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz
+
+# === Multi-word with hash comment ===
+SENTENCE=the quick brown fox # jumps over
+NOSPACE_HASH=foo#bar


### PR DESCRIPTION
Reset to upstream v1.5.1 (safe comment loop with i>0 guard) and add ReadNoExpand function to skip $VAR expansion when reading .env files. Module path updated to github.com/emergentbase/godotenv.