### PR TITLE
fix: don't treat closing quote as escaped after an escaped backslash

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -342,6 +342,9 @@ func TestParsing(t *testing.T) {
 	// parses escaped double quotes
 	parseAndCompare(t, `FOO="escaped\"bar"`, "FOO", `escaped"bar`)
 
+	// a trailing escaped backslash does not escape the closing quote
+	parseAndCompare(t, `FOO="bar\\"`, "FOO", `bar\`)
+
 	// parses single quotes inside double quotes
 	parseAndCompare(t, `FOO="'d'"`, "FOO", `'d'`)
 

--- a/parser.go
+++ b/parser.go
@@ -164,8 +164,12 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 			continue
 		}
 
-		// skip escaped quote symbol (\" or \', depends on quote)
-		if prevChar := src[i-1]; prevChar == '\\' {
+		// skip escaped quote symbol; a quote is escaped only when preceded by an odd number of backslashes
+		backslashes := 0
+		for j := i - 1; j >= 0 && src[j] == '\\'; j-- {
+			backslashes++
+		}
+		if backslashes%2 == 1 {
 			continue
 		}
 


### PR DESCRIPTION
When scanning for a quoted value's terminator, a closing quote was skipped whenever the preceding byte was a backslash, even if that backslash was itself escaped, so `FOO="bar\\"` failed with "unterminated quoted value". The quote is now considered escaped only when preceded by an odd number of backslashes, matching the behaviour of the reference dotenv parsers. Closes #225