### PR TITLE
Definitively commit to allowing hyphens (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ content := getRemoteFileContent()
 myEnv, err := godotenv.Unmarshal(content)
 ```
 
+### Variable name compatibility
+
+Ruby's dotenv only allows `[A-Za-z0-9_.]` in key names, while Node's dotenv also permits `-`. godotenv has matched the Node charset since v1.4.0, so keys like `MY-VAR` parse cleanly here and in Node but will error under Ruby's dotenv.
+
 ### Precedence & Conventions
 
 Existing envs take precedence of envs that are loaded later.

--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -710,10 +710,6 @@ func TestParserErrors(t *testing.T) {
 		input string
 		err   error
 	}{
-		"Invalid char": {
-			input: "foo-1=bar",
-			err:   ErrUnexpectedChar,
-		},
 		"UnterminatedQuote": {
 			input: "foo=\"bar",
 			err:   ErrUnterminatedQuote,


### PR DESCRIPTION
Capturing this background so I don't hopefully forget _again_ what the project policy on hyphens in key names are.

Allowed characters in key names per named upstream inspiration libraries:
  - Ruby dotenv: [\w.]+ — letters, digits, underscore, dot. No hyphen.
  - Node dotenv: [\w.-]+ — letters, digits, underscore, dot, hyphen allowed.

Generally I prefer to follow the ruby implementation, but also not to break backwards compatibility

Context from the repo history:

  - v1.4.0 happened to allow hyphens (accidentally committing to the node character set; a later refactor accidentally broke that.
  - PR #228 added TestParserErrors/Invalid char in March 2024 codifying the hyphen being disallowed (but sat unmerged)
  - PR #245 (commit 82194f2, March 2025) deliberately restored hyphen support, citing the v1.4.0 backwards-compat regression.
  - Commit 65e5809 added TestKeyNameCharsetRejectsDisallowed which locks in [A-Za-z0-9_.-] and explicitly says "If you widen this further, delete the relevant case here on purpose" — i.e. it codifies hyphen-as-allowed.
  - fixtures/hyphen.env + TestLoadHyphenEnv (godotenv_test.go:175ish) also depend on hyphens being valid.
  - Merging #228 in a dumb way via a cleanup branch on c92e518 brought the failing test into main
 
So that was a bit dumb by me trying to rush through some release cleanup. Will do a new-new pre-release.

Have also updated the readme to capture this to avoid future messups.