### PR TITLE
Point CI to new windows tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.26', '1.25', '1.24', '1.23', '1.22' ]
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-latest, macOS-latest, windows-2025-vs2026 ]
     name: ${{ matrix.os }} Go ${{ matrix.go }} Tests
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Per Github warming "NOTICE: windows-latest requests are being redirected to windows-2025-vs2026 by June 15, 2028"