### PR TITLE
fix: parse quoted values without trimming escaped edge quotes

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -368,6 +368,9 @@ func TestParsing(t *testing.T) {
 	// parses escaped double quotes
 	parseAndCompare(t, `FOO="escaped\"bar"`, "FOO", `escaped"bar`)
 
+	// write/read roundtrip preserves escaped quote-only values
+	parseAndCompare(t, `FOO="\"\""`, "FOO", `""`)
+
 	// a trailing escaped backslash does not escape the closing quote
 	parseAndCompare(t, `FOO="bar\\"`, "FOO", `bar\`)
 

--- a/parser.go
+++ b/parser.go
@@ -182,9 +182,10 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 			continue
 		}
 
-		// trim quotes
-		trimFunc := isCharFunc(rune(quote))
-		value = string(bytes.TrimLeftFunc(bytes.TrimRightFunc(src[0:i], trimFunc), trimFunc))
+		// take content between opening and closing quotes; do not trim quote
+		// characters with TrimFunc since escaped quotes at the edges would be
+		// incorrectly removed (see issue #226).
+		value = string(src[1:i])
 		if quote == prefixDoubleQuote {
 			// unescape newlines for double quote (this is compat feature)
 			// and expand environment variables


### PR DESCRIPTION
## Summary
- Fix parsing of double-quoted values whose content ends with escaped quote characters
- Replace `TrimLeftFunc`/`TrimRightFunc` quote stripping with `src[1:i]`, since the closing quote position is already known

## Problem
For a value like `""` written as `foo="\"\""`, the parser used `TrimRightFunc` to remove quote characters from the parsed slice. That incorrectly stripped an escaped closing quote and left a stray backslash in the value.

## Test plan
- [x] `go test ./...`
- [x] Added regression test for `FOO="\"\""` => `""`
- [x] Verified Write/Read roundtrip for quote-only values

Fixes #226