### PR TITLE
fix: allow parentheses in environment variable names

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -705,6 +705,27 @@ func TestWhitespace(t *testing.T) {
 	}
 }
 
+func TestUnmarshalWindowsEnvVarWithParenthesesInKey(t *testing.T) {
+	testEnv := `
+DP_WORK_DIR=C:\\User
+TEST=${DP_WORK_DIR}\\test
+CommonProgramFiles(x86)=C:\Program Files (x86)\Common Files
+`
+	result, err := Unmarshal(testEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"DP_WORK_DIR":                `C:\\User`,
+		"TEST":                       `C:\\User\\test`,
+		"CommonProgramFiles(x86)":    `C:\Program Files (x86)\Common Files`,
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, result)
+	}
+}
+
 func TestParserErrors(t *testing.T) {
 	cases := map[string]struct {
 		input string

--- a/parser.go
+++ b/parser.go
@@ -104,8 +104,8 @@ loop:
 			break loop
 		case '_':
 		default:
-			// variable name should match [A-Za-z0-9_.-]
-			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) || rchar == '.' || rchar == '-' {
+			// variable name should match [A-Za-z0-9_.()-]
+			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) || rchar == '.' || rchar == '-' || rchar == '(' || rchar == ')' {
 				continue
 			}
 


### PR DESCRIPTION
## Summary

Fixes #250

Windows system environment variables such as `CommonProgramFiles(x86)` include parentheses in their names. The parser previously rejected `(` in variable names, causing `Unmarshal` to fail when parsing `.env` files that mirror Windows environment exports.

## Changes

- Allow `(` and `)` in variable names when locating keys in `locateKeyName`
- Add regression test covering a Windows-style env block with variable expansion

## Test plan

- [x] `go test ./...`
- [x] Added `TestUnmarshalWindowsEnvVarWithParenthesesInKey` reproducing the reported failure