### PR TITLE
fix: guard inline comment detection at unquoted value start

### DIFF
--- a/godotenv_test.go
+++ b/godotenv_test.go
@@ -416,6 +416,8 @@ func TestParsing(t *testing.T) {
 	// it 'ignores inline comments' do
 	// expect(env("foo=bar # this is foo")).to eql('foo' => 'bar')
 	parseAndCompare(t, "FOO=bar # this is foo", "FOO", "bar")
+	parseAndCompare(t, "FOO=#hash", "FOO", "#hash")
+	parseAndCompare(t, "FOO=# trailing", "FOO", "# trailing")
 
 	// it 'allows # in quoted value' do
 	// expect(env('foo="bar#baz" # comment')).to eql('foo' => 'bar#baz')

--- a/parser.go
+++ b/parser.go
@@ -154,11 +154,9 @@ func extractVarValue(src []byte, vars map[string]string) (value string, rest []b
 		// Work backwards to check if the line ends in whitespace then
 		// a comment, ie: foo=bar # baz # other
 		for i := 0; i < endOfVar; i++ {
-			if line[i] == charComment && i < endOfVar {
-				if isSpace(line[i-1]) {
-					endOfVar = i
-					break
-				}
+			if i > 0 && line[i] == charComment && isSpace(line[i-1]) {
+				endOfVar = i
+				break
 			}
 		}
 


### PR DESCRIPTION
## Summary

When parsing unquoted env values, inline comment detection walks the value bytes and treats `#` preceded by whitespace as the start of a comment. At `i == 0` the previous check used `line[i-1]`, which in Go reads the **last** byte of the slice—not a byte before the value.

That can incorrectly truncate values that start with `#`, especially when the value also ends with whitespace (e.g. `FOO=# trailing`).

This change only treats `#` as an inline comment when `i > 0` and the preceding byte is whitespace.

Fixes #214

## Test plan

- [x] `go test ./...`
- [x] Added cases for unquoted values starting with `#` (`FOO=#hash`, `FOO=# trailing`)
- [x] Existing inline comment tests still pass (`FOO=bar # comment`, quoted `#` in values)